### PR TITLE
make: Explicitly set DOCKER_BUILDKIT=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL=/usr/bin/env bash
 PYTORCH_DOWNLOAD_LINK ?= https://download.pytorch.org/whl/test/cu101/torch_test.html
 # Used by CI to do plain buildkit progress
 BUILD_PROGRESS        ?=
-DOCKER_BUILD           = cat Dockerfile | docker build --target $@ $(BUILD_PROGRESS) --build-arg "PYTORCH_DOWNLOAD_LINK=$(PYTORCH_DOWNLOAD_LINK)" -t pytorch/integration-testing:$@ -
+DOCKER_BUILD           = cat Dockerfile | DOCKER_BUILDKIT=1 docker build --target $@ $(BUILD_PROGRESS) --build-arg "PYTORCH_DOWNLOAD_LINK=$(PYTORCH_DOWNLOAD_LINK)" -t pytorch/integration-testing:$@ -
 DOCKER_RUN             = set -o pipefail; docker run --rm -it --gpus all --shm-size 8G -v "$(PWD)/output:/output" pytorch/integration-testing:$@
 CHOWN_TO_USER          = docker run --rm -v "$(PWD)":/v -w /v alpine chown -R "$(shell id -u):$(shell id -g)" .
 


### PR DESCRIPTION
Makes it so that DOCKER_BUILDKIT is always set

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>