### PR TITLE
Remove fastai for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ workflows:
             - run_test:
                 matrix:
                     parameters:
-                        target: ["fastai", "pyro", "detectron2", "transformers", "fairseq"]
+                        target: ["pyro", "detectron2", "transformers", "fairseq"]
                 requires:
                     - hold
             - run_compat_test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,6 @@ RUN pip install \
         torchtext \
         -f ${PYTORCH_DOWNLOAD_LINK}
 
-FROM base as fastai
-RUN git clone --branch 1.0.61 https://github.com/fastai/fastai.git /fastai
-WORKDIR /fastai
-RUN tools/run-after-git-clone && pip install ".[dev]" && pip install pytest pytest-runner
-
 FROM base as pyro
 # Needed to build pillow from source
 RUN apt-get install -y \

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,6 @@ all:
 logs/:
 	mkdir -p logs/
 
-.PHONY: fastai
-fastai: logs/
-	$(DOCKER_BUILD)
-	$(DOCKER_RUN) pip list > logs/$@_metadata.log
-	$(DOCKER_RUN) py.test -v --color=no --junitxml=/output/$@_results.xml tests | tee logs/$@.log
-
 .PHONY: pyro
 pyro: logs/
 	$(DOCKER_BUILD)


### PR DESCRIPTION
The V2 upgrade made it so that the way to run tests is completely
different, we need to re-evaluate how to do this

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>