### PR TITLE
compat-tests: Switch to run all tests in one call

### DIFF
--- a/compat-tests/entrypoint.sh
+++ b/compat-tests/entrypoint.sh
@@ -4,11 +4,9 @@
 
 set -eou pipefail
 
-CPP_EXTENSION_TESTS="test_cpp_extensions_aot_no_ninja test_cpp_extensions_aot_ninja test_cpp_extensions_jit test_cpp_api_parity"
 (
     set -x
-    python -u run_test.py -v -x ${CPP_EXTENSION_TESTS}
-    python -u run_test.py -v -i ${CPP_EXTENSION_TESTS}
+    python -u run_test.py --continue-through-error -v
 )
 
 (


### PR DESCRIPTION
Also makes it so that we will continue execution through error and gain
signal on all test suites.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>