### PR TITLE
compat-tests: add protobuf as a dependency

### DIFF
--- a/compat-tests/Dockerfile
+++ b/compat-tests/Dockerfile
@@ -39,6 +39,7 @@ RUN conda install -c pytorch-test \
         pytorch \
         pyyaml \
         psutil \
+        protobuf \
         six
 RUN conda install -c conda-forge unittest-xml-reporting
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Apparently protobuf is required for some of the tests

cc @pytorch/pytorch-dev-infra 

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>