### PR TITLE
First attempt at adding MacOS compatibility tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,16 @@ jobs:
     macos_compat_build:
         macos:
             xcode: 12.0
+        parameters:
+            pytorch_channel:
+                type: string
+                default: pytorch-test
+            pytorch_ref:
+                type: string
+                default: master
         environment:
-            - PYTORCH_REF=master
+            - PYTORCH_CHANNEL=<< parameters.pytorch_channel >>
+            - PYTORCH_REF=<< parameters.pytorch_ref >>
         steps:
             - checkout
             - run:
@@ -86,7 +94,7 @@ jobs:
                 name: Install Dependencies and Run MacOS Compatibility Tests
                 command: |
                     export PATH=$HOME/miniconda/bin:$PATH
-                    conda install -y -c pytorch-test cpuonly future hypothesis ninja numpy pillow pytorch pyyaml psutil protobuf six
+                    conda install -y -c ${PYTORCH_CHANNEL} cpuonly future hypothesis ninja numpy pillow pytorch pyyaml psutil protobuf six
                     conda install -y -c conda-forge openmp unittest-xml-reporting
                     make -C compat-tests macos-compat
             - store_test_results:
@@ -113,5 +121,8 @@ workflows:
                 requires:
                     - hold
             - macos_compat_build:
+                matrix:
+                    parameters:
+                        pytorch_ref: ["v1.7.0-rc2"]
                 requires:
                     - hold

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,16 +82,15 @@ jobs:
                 command: |
                     curl --retry 3 -o install_conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
                     sh install_conda.sh -b -p $HOME/miniconda
-                    export PATH=$PATH:$HOME/miniconda/bin
-                    alias python=python3
             - run:
                 name: Install Dependencies and pytorch-test
                 command: |
+                    export PATH=$PATH:$HOME/miniconda/bin
                     conda install -y -c pytorch-test cpuonly future hypothesis ninja numpy pillow pytorch pyyaml psutil protobuf six
                     conda install -y -c conda-forge openmp unittest-xml-reporting
             - run:
                 name: Running MacOS compatibility tests
-                command: make -C compat-tests macos-compat
+                command: alias python=python3 && make -C compat-tests macos-compat
             - store_test_results:
                 path: pytorch/test/test-reports
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,17 +82,18 @@ jobs:
                 command: |
                     curl --retry 3 -o install_conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
                     sh install_conda.sh -b -p $HOME/miniconda
-                    export PATH=$PATH:$HOME/miniconda
+                    export PATH=$PATH:$HOME/miniconda/bin
+                    alias python=python3
             - run:
                 name: Install Dependencies and pytorch-test
                 command: |
-                    conda install -c pytorch-test cpuonly future hypothesis ninja numpy openmp pillow pytorch pyyaml psutil protobuf six
-                    conda install -c conda-forge unittest-xml-reporting
+                    conda install -y -c pytorch-test cpuonly future hypothesis ninja numpy pillow pytorch pyyaml psutil protobuf six
+                    conda install -y -c conda-forge openmp unittest-xml-reporting
             - run:
                 name: Running MacOS compatibility tests
                 command: make -C compat-tests macos-compat
             - store_test_results:
-                path: test-reports
+                path: pytorch/test/test-reports
 
 workflows:
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,3 +114,6 @@ workflows:
                         pytorch_ref: ["v1.7.0-rc2"]
                 requires:
                     - hold
+            - macos_compat_build:
+                requires:
+                    - hold

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,14 +83,12 @@ jobs:
                     curl --retry 3 -o install_conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
                     sh install_conda.sh -b -p $HOME/miniconda
             - run:
-                name: Install Dependencies and pytorch-test
+                name: Install Dependencies and Run MacOS Compatibility Tests
                 command: |
-                    export PATH=$PATH:$HOME/miniconda/bin
+                    export PATH=$HOME/miniconda/bin:$PATH
                     conda install -y -c pytorch-test cpuonly future hypothesis ninja numpy pillow pytorch pyyaml psutil protobuf six
                     conda install -y -c conda-forge openmp unittest-xml-reporting
-            - run:
-                name: Running MacOS compatibility tests
-                command: alias python=python3 && make -C compat-tests macos-compat
+                    make -C compat-tests macos-compat
             - store_test_results:
                 path: pytorch/test/test-reports
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,13 +75,14 @@ jobs:
             - run:
                 name: Checkout PyTorch
                 command: |
-                    git clone https://github.com/pytorch/pytorch.git /pytorch
-                    git -C /pytorch checkout ${PYTORCH_REF} && git -C /pytorch submodule update --init --recursive
+                    git clone https://github.com/pytorch/pytorch.git pytorch
+                    git -C pytorch checkout ${PYTORCH_REF} && git -C pytorch submodule update --init --recursive
             - run:
                 name: Install Miniconda
                 command: |
                     curl --retry 3 -o install_conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-                    sh install_conda.sh -b -p /home/circleci/project/miniconda
+                    sh install_conda.sh -b -p $HOME/miniconda
+                    export PATH=$PATH:$HOME/miniconda
             - run:
                 name: Install Dependencies and pytorch-test
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,34 @@ jobs:
             - store_test_results:
                 path: test-reports
 
+    macos_compat_build:
+        macos:
+            xcode: 12.0
+        environment:
+            - PYTORCH_REF=master
+        steps:
+            - checkout
+            - run:
+                name: Checkout PyTorch
+                command: |
+                    git clone https://github.com/pytorch/pytorch.git /pytorch
+                    git -C /pytorch checkout ${PYTORCH_REF} && git -C /pytorch submodule update --init --recursive
+            - run:
+                name: Install Miniconda
+                command: |
+                    curl --retry 3 -o install_conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+                    sh install_conda.sh -b -p /home/circleci/project/miniconda
+            - run:
+                name: Install Dependencies and pytorch-test
+                command: |
+                    conda install -c pytorch-test cpuonly future hypothesis ninja numpy openmp pillow pytorch pyyaml psutil protobuf six
+                    conda install -c conda-forge unittest-xml-reporting
+           - run:
+                name: Running MacOS compatibility tests
+                command: make -C compat-tests macos-compat
+            - store_test_results:
+                path: test-reports
+
 workflows:
     run:
         jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
                 command: |
                     conda install -c pytorch-test cpuonly future hypothesis ninja numpy openmp pillow pytorch pyyaml psutil protobuf six
                     conda install -c conda-forge unittest-xml-reporting
-           - run:
+            - run:
                 name: Running MacOS compatibility tests
                 command: make -C compat-tests macos-compat
             - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
                     export PATH=$HOME/miniconda/bin:$PATH
                     conda install -y -c ${PYTORCH_CHANNEL} cpuonly future hypothesis ninja numpy pillow pytorch pyyaml psutil protobuf six
                     conda install -y -c conda-forge openmp unittest-xml-reporting
-                    make -C compat-tests macos-compat
+                    IN_CIRCLECI=1 make -C compat-tests macos-compat
             - store_test_results:
                 path: pytorch/test/test-reports
 

--- a/compat-tests/Makefile
+++ b/compat-tests/Makefile
@@ -47,4 +47,4 @@ archlinux:
 
 .PHONY: macos-compat
 macos-compat:
-	./entrypoint.sh
+	cd ../pytorch/test && ../../compat-tests/entrypoint.sh

--- a/compat-tests/Makefile
+++ b/compat-tests/Makefile
@@ -44,3 +44,7 @@ archlinux: BASE       := arch-base
 archlinux:
 	$(DOCKER_BUILD)
 	$(DOCKER_RUN) | tee $@.log
+
+.PHONY: macos-compat
+macos-compat:
+	./entrypoint.sh

--- a/compat-tests/README.md
+++ b/compat-tests/README.md
@@ -1,4 +1,4 @@
 # pytorch-compat-test
 
-Runs the pytorch test suite along with some other compatability tests for
+Runs the pytorch test suite along with some other compatibility tests for
 the lastest release available on the anaconda channel `pytorch-test`


### PR DESCRIPTION
A draft--this does not work right now--of adding macOS compat-tests. 

Added Makefile target to run ./entrypoint.sh.
Added what I think are some pre-reqs in CircleCI.