### PR TITLE
Adding IN_CI=1 since the IN_CIRCLECI flag will be deprecated soon.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
                     export PATH=$HOME/miniconda/bin:$PATH
                     conda install -y -c ${PYTORCH_CHANNEL} cpuonly future hypothesis ninja numpy pillow pytorch pyyaml psutil protobuf six
                     conda install -y -c conda-forge openmp unittest-xml-reporting
-                    IN_CIRCLECI=1 make -C compat-tests macos-compat
+                    IN_CIRCLECI=1 IN_CI=1 make -C compat-tests macos-compat
             - store_test_results:
                 path: pytorch/test/test-reports
 

--- a/compat-tests/Makefile
+++ b/compat-tests/Makefile
@@ -15,7 +15,7 @@ DOCKER_BUILD = docker build \
 	--build-arg PYTORCH_REF=$(PYTORCH_REF) \
 	--build-arg PYTORCH_CHANNEL=$(PYTORCH_CHANNEL) \
 	.
-DOCKER_RUN   = set -o pipefail; docker run --rm -it -e IN_CIRCLECI=1  -w /pytorch/test -v "$(PWD)/test-reports:/pytorch/test/test-reports" compat-test:$@
+DOCKER_RUN   = set -o pipefail; docker run --rm -it -e IN_CIRCLECI=1 IN_CI=1 -w /pytorch/test -v "$(PWD)/test-reports:/pytorch/test/test-reports" compat-test:$@
 
 .PHONY: ubuntu-16.04
 ubuntu-16.04: BASE_IMAGE := ubuntu:16.04

--- a/compat-tests/Makefile
+++ b/compat-tests/Makefile
@@ -15,7 +15,7 @@ DOCKER_BUILD = docker build \
 	--build-arg PYTORCH_REF=$(PYTORCH_REF) \
 	--build-arg PYTORCH_CHANNEL=$(PYTORCH_CHANNEL) \
 	.
-DOCKER_RUN   = set -o pipefail; docker run --rm -it -e IN_CIRCLECI=1 IN_CI=1 -w /pytorch/test -v "$(PWD)/test-reports:/pytorch/test/test-reports" compat-test:$@
+DOCKER_RUN   = set -o pipefail; docker run --rm -it -e IN_CIRCLECI=1 -e IN_CI=1 -w /pytorch/test -v "$(PWD)/test-reports:/pytorch/test/test-reports" compat-test:$@
 
 .PHONY: ubuntu-16.04
 ubuntu-16.04: BASE_IMAGE := ubuntu:16.04


### PR DESCRIPTION
In anticipation of newer PyTorch changes that deprecates IN_CIRCLECI argument [(PR 46567)](https://github.com/pytorch/pytorch/pull/46567), this PR adds its new variable name as an environment for a smooth transition in the future.

We will remove IN_CIRCLECI once the time comes.