### PR TITLE
Dedicate a large machine for macOS compat tests to increase runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ jobs:
     macos_compat_build:
         macos:
             xcode: 12.0
+        resource_class: large
         parameters:
             pytorch_channel:
                 type: string


### PR DESCRIPTION
The current tests take 4 hours to run and has 59 failures, which should be eliminated by using a larger instance.