### PR TITLE
Setup vLLM benchmark CI for H100

### DIFF
--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -13,7 +13,7 @@ jobs:
   benchmark-h100:
     name: Run vLLM benchmarks
     runs-on: linux.aws.h100.4
-    secrets: inherit
+    environment: ${{ github.ref == 'refs/heads/main' && 'pytorch-x-vllm' || 'pytorch-x-vllm' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -1,4 +1,4 @@
-name: VLLM Benchmark
+name: vLLM Benchmark
 
 on:
   schedule:
@@ -82,9 +82,12 @@ jobs:
         run:
           set -x
 
-          docker ps -a
-#          docker run \
-#            ${GPU_FLAG:-} \
+          docker run \
+            ${GPU_FLAG:-} \
+            "${DOCKER_IMAGE}" \
+            "ls -la"
+
+
 #            ${SCCACHE_SERVER_PORT_DOCKER_FLAG:-} \
 #            -e SCCACHE_BUCKET \
 #            -e SCCACHE_REGION \

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -81,7 +81,7 @@ jobs:
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
           DOCKER_IMAGE: public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:${{ env.HEAD_SHA }}
         run:
-          set -eux
+          set -x
 
           container_name=$(docker run \
             ${GPU_FLAG:-} \
@@ -96,7 +96,8 @@ jobs:
             --detach \
             -v "${GITHUB_WORKSPACE}:/tmp/workspace" \
             -w /tmp/workspace \
-            "${DOCKER_IMAGE}"
+            "${DOCKER_IMAGE}" \
+            ""
           )
 
           docker exec -t "${container_name}" sh -c "ls -la"

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -43,17 +43,17 @@ jobs:
           HEAD_BRANCH=main
 
           # Get the last green commit from S3
-          S3_PATH="last-green-commits/vllm-project/vllm/${HEAD_BRANCH}/${GPU_DEVICE}/commit"
-          NOT_EXIST=0
-          aws s3api head-object --bucket ossci-benchmarks --key ${S3_PATH} || NOT_EXIST=1
+          # S3_PATH="last-green-commits/vllm-project/vllm/${HEAD_BRANCH}/${GPU_DEVICE}/commit"
+          # NOT_EXIST=0
+          # aws s3api head-object --bucket ossci-benchmarks --key ${S3_PATH} || NOT_EXIST=1
 
-          if [[ ${NOT_EXIST} == "0" ]]; then
-            aws s3 cp "s3://ossci-benchmarks/${S3_PATH}" .
-            LAST_GREEN_COMMIT=$(cat commit)
-            echo "LAST_GREEN_COMMIT=$LAST_GREEN_COMMIT" >> $GITHUB_ENV
-          else
-            echo "LAST_GREEN_COMMIT=none" >> $GITHUB_ENV
-          fi
+          # if [[ ${NOT_EXIST} == "0" ]]; then
+          #   aws s3 cp "s3://ossci-benchmarks/${S3_PATH}" .
+          #   LAST_GREEN_COMMIT=$(cat commit)
+          #   echo "LAST_GREEN_COMMIT=$LAST_GREEN_COMMIT" >> $GITHUB_ENV
+          # else
+          #   echo "LAST_GREEN_COMMIT=none" >> $GITHUB_ENV
+          # fi
 
           pushd vllm
           HEAD_SHA=$(git rev-parse --verify HEAD)

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -65,10 +65,7 @@ jobs:
         run:
           set -x
 
-          docker run --gpus all \
-            -e NVIDIA_DRIVER_CAPABILITIES=all \
-            "${DOCKER_IMAGE}" \
-            bash -xc ls -la
+          docker run --gpus all -e NVIDIA_DRIVER_CAPABILITIES=all "${DOCKER_IMAGE}" bash -xc "ls -la"
 
 
 #            ${SCCACHE_SERVER_PORT_DOCKER_FLAG:-} \

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -50,14 +50,14 @@ jobs:
           HEAD_BRANCH=main
 
           pushd vllm
-          for i in {0..9}
+          # Looking back the latest 100 commits is probably enough
+          for i in {0..99}
           do
             # Check if image already exists, if it does then check an older one
             HEAD_SHA=$(git rev-parse --verify HEAD~${i})
             DOCKER_IMAGE="${DOCKER_IMAGE_PREFIX}:${HEAD_SHA}"
 
             if docker manifest inspect "${DOCKER_IMAGE}"; then
-              echo "${DOCKER_IMAGE} doesn't exist, this usually means that the commit has just been landed in vLLM and the image hasn't finished building yet"
               break
             fi
           done

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -99,4 +99,4 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/tmp/workspace" \
             -w /tmp/workspace \
             "${DOCKER_IMAGE}" \
-            bash -xc "cd vllm-benchmarks/vllm && .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh && ls -lah benchmarks/results"
+            bash -xc "cd vllm-benchmarks/vllm && bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh && ls -lah benchmarks/results"

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -3,7 +3,7 @@ name: vLLM Benchmark
 on:
   schedule:
     # Run every 2 hours
-    - cron: '0 */2 * * *'
+    - cron: '0 */1 * * *'
   workflow_dispatch:
   pull_request:
     paths:
@@ -30,12 +30,6 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Setup benchmark tests
-        working-directory: vllm-benchmarks
-        run: |
-          # Set the list of benchmarks we want to cover in PyTorch infra
-          cp -r benchmarks/*.json vllm/.buildkite/nightly-benchmarks/tests
-
       - name: Set GPU device name
         working-directory: vllm-benchmarks
         run: |
@@ -45,9 +39,10 @@ jobs:
       - name: Check for last benchmark commit
         working-directory: vllm-benchmarks
         env:
+          HEAD_BRANCH: main
           DOCKER_IMAGE_PREFIX: public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo
         run: |
-          HEAD_BRANCH=main
+          pip install awscli
 
           pushd vllm
           # Looking back the latest 100 commits is enough
@@ -58,8 +53,17 @@ jobs:
             HEAD_SHA=$(git rev-parse --verify HEAD~${i})
             DOCKER_IMAGE="${DOCKER_IMAGE_PREFIX}:${HEAD_SHA}"
 
-            # TODO: SKIP COMMIT THAT HAS ALREADY BEEN RUN
-            if docker manifest inspect "${DOCKER_IMAGE}"; then
+            # No Docker image available yet because the commit is too recent
+            if ! docker manifest inspect "${DOCKER_IMAGE}"; then
+              continue
+            fi
+
+            NOT_EXIST=0
+            S3_PATH="v3/vllm-project/vllm/${HEAD_BRANCH}/${HEAD_SHA}/${GPU_DEVICE}/benchmark_results.json"
+            aws s3api head-object --bucket ossci-benchmarks --key ${S3_PATH} || NOT_EXIST=1
+
+            if [[ ${NOT_EXIST} == "1" ]]; then
+              echo "Found vLLM commit ${HEAD_SHA} hasn't been benchmarked yet"
               break
             fi
           done
@@ -74,6 +78,16 @@ jobs:
       - name: Setup SCCACHE_SERVER_PORT environment for docker run when on container
         run: |
           echo "SCCACHE_SERVER_PORT_DOCKER_FLAG=-e SCCACHE_SERVER_PORT=$((RUNNER_UID + 4226))" >> "${GITHUB_ENV}"
+
+      - name: Setup benchmark tests
+        working-directory: vllm-benchmarks
+        run: |
+          pushd vllm
+          git checkout "${HEAD_SHA}"
+          popd
+
+          # Set the list of benchmarks we want to cover in PyTorch infra
+          cp -r benchmarks/*.json vllm/.buildkite/nightly-benchmarks/tests
 
       - name: Run vLLM benchmark
         env:
@@ -104,8 +118,16 @@ jobs:
 
       - name: Upload the benchmark results
         working-directory: vllm-benchmarks
+        env:
+          BENCHMARK_RESULTS: vllm/benchmarks/results
+          HEAD_BRANCH: main
         run: |
           set -eux
 
-          sudo chown ${UID} vllm/benchmarks/results
-          ls -lah vllm/benchmarks/results
+          sudo chown ${UID} "${BENCHMARK_RESULTS}"
+          ls -lah "${BENCHMARK_RESULTS}"
+
+          python upload_benchmark_results.py \
+            --vllm vllm \
+            --benchmark-results "${BENCHMARK_RESULTS}" \
+            --device "${GPU_DEVICE}"

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -42,6 +42,8 @@ jobs:
           HEAD_BRANCH: main
           DOCKER_IMAGE_PREFIX: public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo
         run: |
+          set -eux
+
           pip install awscli
 
           pushd vllm
@@ -63,7 +65,7 @@ jobs:
             aws s3api head-object --bucket ossci-benchmarks --key ${S3_PATH} || NOT_EXIST=1
 
             if [[ ${NOT_EXIST} == "1" ]]; then
-              echo "Found vLLM commit ${HEAD_SHA} hasn't been benchmarked yet"
+              echo "Found a vLLM commit ${HEAD_SHA} that hasn't been benchmarked yet"
               break
             fi
           done

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -9,6 +9,10 @@ on:
     paths:
       - .github/workflows/vllm-benchmark.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  cancel-in-progress: true
+
 jobs:
   benchmark-h100:
     name: Run vLLM benchmarks
@@ -24,6 +28,7 @@ jobs:
           repository: vllm-project/vllm
           path: vllm-benchmarks/vllm
           ref: main
+          fetch-depth: 0
 
       - name: Setup benchmark tests
         working-directory: vllm-benchmarks
@@ -39,11 +44,23 @@ jobs:
 
       - name: Check for last benchmark commit
         working-directory: vllm-benchmarks
+        env:
+          DOCKER_IMAGE_PREFIX: public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo
         run: |
           HEAD_BRANCH=main
 
           pushd vllm
-          HEAD_SHA=$(git rev-parse --verify HEAD)
+          for i in {0..9}
+          do
+            # Check if image already exists, if it does then check an older one
+            HEAD_SHA=$(git rev-parse --verify HEAD~${i})
+            DOCKER_IMAGE="${DOCKER_IMAGE_PREFIX}:${HEAD_SHA}"
+
+            if docker manifest inspect "${DOCKER_IMAGE}"; then
+              echo "${DOCKER_IMAGE} doesn't exist, this usually means that the commit has just been landed in vLLM and the image hasn't finished building yet"
+              break
+            fi
+          done
           popd
 
           echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_ENV

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -119,6 +119,8 @@ jobs:
             -e SCCACHE_REGION \
             -e GPU_DEVICE \
             -e HF_TOKEN \
+            -e ENGINE_VERSION \
+            -e SAVE_TO_PYTORCH_BENCHMARK_FORMAT \
             --ipc=host \
             --tty \
             --security-opt seccomp=unconfined \
@@ -142,5 +144,3 @@ jobs:
             --vllm vllm \
             --benchmark-results "${BENCHMARK_RESULTS}" \
             --device "${GPU_DEVICE}"
-
-          sleep 3600

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -30,6 +30,11 @@ jobs:
           ref: main
           fetch-depth: 0
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
       - name: Set GPU device name
         working-directory: vllm-benchmarks
         run: |

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -142,3 +142,5 @@ jobs:
             --vllm vllm \
             --benchmark-results "${BENCHMARK_RESULTS}" \
             --device "${GPU_DEVICE}"
+
+          sleep 3600

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -55,6 +55,9 @@ jobs:
           #   echo "LAST_GREEN_COMMIT=none" >> $GITHUB_ENV
           # fi
 
+          # DEBUG
+          echo "LAST_GREEN_COMMIT=none" >> $GITHUB_ENV
+
           pushd vllm
           HEAD_SHA=$(git rev-parse --verify HEAD)
           popd

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -79,6 +79,9 @@ jobs:
           SCCACHE_REGION: us-east-1
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
           DOCKER_IMAGE: public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:${{ env.HEAD_SHA }}
+          # vLLM-related environment variables
+          ENGINE_VERSION: v1
+          SAVE_TO_PYTORCH_BENCHMARK_FORMAT: 1
         run: |
           set -x
 
@@ -96,4 +99,4 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/tmp/workspace" \
             -w /tmp/workspace \
             "${DOCKER_IMAGE}" \
-            bash -xc "id; cd vllm-benchmarks/vllm; ls -lah; ls -lah .git; ls -lah .buildkite/nightly-benchmarks/tests; git diff"
+            bash -xc "cd vllm-benchmarks/vllm && .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh && ls -lah benchmarks/results"

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -95,4 +95,4 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/tmp/workspace" \
             -w /tmp/workspace \
             "${DOCKER_IMAGE}" \
-            bash -xc "cd vllm-benchmarks/vllm; ls -lah; ls -lah .buildkite/nightly-benchmarks/tests; git diff"
+            bash -xc "id; cd vllm-benchmarks/vllm; ls -lah; ls -lah .git; ls -lah .buildkite/nightly-benchmarks/tests; git diff"

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -82,21 +82,22 @@ jobs:
         run:
           set -x
 
-          docker run \
-            ${GPU_FLAG:-} \
-            ${SCCACHE_SERVER_PORT_DOCKER_FLAG:-} \
-            -e SCCACHE_BUCKET \
-            -e SCCACHE_REGION \
-            -e HUGGING_FACE_HUB_TOKEN \
-            --security-opt seccomp=unconfined \
-            --cap-add=SYS_PTRACE \
-            --ipc=host \
-            --tty \
-            --detach \
-            -v "${GITHUB_WORKSPACE}:/tmp/workspace" \
-            -w /tmp/workspace \
-            "${DOCKER_IMAGE}" \
-            "ls -la"
+          docker ps -a
+#          docker run \
+#            ${GPU_FLAG:-} \
+#            ${SCCACHE_SERVER_PORT_DOCKER_FLAG:-} \
+#            -e SCCACHE_BUCKET \
+#            -e SCCACHE_REGION \
+#            -e HUGGING_FACE_HUB_TOKEN \
+#            --security-opt seccomp=unconfined \
+#            --cap-add=SYS_PTRACE \
+#            --ipc=host \
+#            --tty \
+#            --detach \
+#            -v "${GITHUB_WORKSPACE}:/tmp/workspace" \
+#            -w /tmp/workspace \
+#            "${DOCKER_IMAGE}" \
+#            "ls -la"
 
 #      - name: Setup Python
 #        uses: actions/setup-python@v5

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -62,12 +62,13 @@ jobs:
           SCCACHE_REGION: us-east-1
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
           DOCKER_IMAGE: public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:${{ env.HEAD_SHA }}
+          NVIDIA_DRIVER_CAPABILITIES: all
         run:
           set -x
 
           docker run \
             --gpus all \
-            -e NVIDIA_DRIVER_CAPABILITIES=all \
+            -e NVIDIA_DRIVER_CAPABILITIES \
             "${DOCKER_IMAGE}" \
             bash -xc ls -la
 

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -135,7 +135,7 @@ jobs:
         run: |
           set -eux
 
-          sudo chown ${UID} "${BENCHMARK_RESULTS}"
+          sudo chown -R ${UID} "${BENCHMARK_RESULTS}"
           ls -lah "${BENCHMARK_RESULTS}"
 
           python upload_benchmark_results.py \

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -85,6 +85,7 @@ jobs:
           docker run \
             ${GPU_FLAG:-} \
             ${SCCACHE_SERVER_PORT_DOCKER_FLAG:-} \
+            -u "${UID}" \
             -e SCCACHE_BUCKET \
             -e SCCACHE_REGION \
             -e GPU_DEVICE \

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -62,13 +62,11 @@ jobs:
           SCCACHE_REGION: us-east-1
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
           DOCKER_IMAGE: public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:${{ env.HEAD_SHA }}
-          NVIDIA_DRIVER_CAPABILITIES: all
         run:
           set -x
 
-          docker run \
-            --gpus all \
-            -e NVIDIA_DRIVER_CAPABILITIES \
+          docker run --gpus all \
+            -e NVIDIA_DRIVER_CAPABILITIES=all \
             "${DOCKER_IMAGE}" \
             bash -xc ls -la
 

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -74,7 +74,6 @@ jobs:
 
       - name: Run vLLM benchmark
         if: env.LAST_GREEN_COMMIT == 'none'
-        shell: bash
         env:
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
           SCCACHE_REGION: us-east-1

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -3,7 +3,7 @@ name: vLLM Benchmark
 on:
   schedule:
     # Run every 2 hours
-    - cron: '0 */1 * * *'
+    - cron: '0 */2 * * *'
   workflow_dispatch:
   pull_request:
     paths:

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -17,7 +17,7 @@ jobs:
   benchmark-h100:
     name: Run vLLM benchmarks
     runs-on: linux.aws.h100.4
-    environment: ${{ github.ref == 'refs/heads/main' && 'pytorch-x-vllm' || 'pytorch-x-vllm' }}
+    environment: pytorch-x-vllm
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -77,7 +77,7 @@ jobs:
         env:
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
           SCCACHE_REGION: us-east-1
-          HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
           DOCKER_IMAGE: public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:${{ env.HEAD_SHA }}
           # vLLM-related environment variables
           ENGINE_VERSION: v1
@@ -92,7 +92,7 @@ jobs:
             -e SCCACHE_BUCKET \
             -e SCCACHE_REGION \
             -e GPU_DEVICE \
-            -e HUGGING_FACE_HUB_TOKEN \
+            -e HF_TOKEN \
             --ipc=host \
             --tty \
             --security-opt seccomp=unconfined \

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -2,9 +2,9 @@ name: vLLM Benchmark
 
 on:
   schedule:
-    # Run every 6 hours (4 times a day)
-    - cron: '0 */6 * * *'
-  workflow_dispatch:  # Allow manual triggering
+    # Run every 2 hours
+    - cron: '0 */2 * * *'
+  workflow_dispatch:
   pull_request:
     paths:
       - .github/workflows/vllm-benchmark.yml
@@ -95,4 +95,4 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/tmp/workspace" \
             -w /tmp/workspace \
             "${DOCKER_IMAGE}" \
-            bash -xc "ls -la"
+            bash -xc "cd vllm-benchmarks/vllm; ls -lah; ls -lah .buildkite/nightly-benchmarks/tests; git diff"

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -69,7 +69,7 @@ jobs:
             --gpus all \
             -e NVIDIA_DRIVER_CAPABILITIES=all \
             "${DOCKER_IMAGE}" \
-            bash -xc "ls -la"
+            bash -xc ls -la
 
 
 #            ${SCCACHE_SERVER_PORT_DOCKER_FLAG:-} \

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -66,4 +66,4 @@ jobs:
           set -x
 
           # TODO(huydhn): I don't know why backlash doesn't work here
-          docker run ${GPU_FLAG:-} ${SCCACHE_SERVER_PORT_DOCKER_FLAG:-} -e SCCACHE_BUCKET -e SCCACHE_REGION -e GPU_DEVICE -e HUGGING_FACE_HUB_TOKEN --ipc=host --tty --security-opt seccomp=unconfined -v "${GITHUB_WORKSPACE}:/tmp/workspace" -w /tmp/workspace "${DOCKER_IMAGE}" bash -xc "ls -la"
+          docker run ${GPU_FLAG:-} ${SCCACHE_SERVER_PORT_DOCKER_FLAG:-} -e SCCACHE_BUCKET -e SCCACHE_REGION -e GPU_DEVICE -e HUGGING_FACE_HUB_TOKEN --ipc=host --tty -v "${GITHUB_WORKSPACE}:/tmp/workspace" -w /tmp/workspace "${DOCKER_IMAGE}" bash -xc "ls -la"

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -1,0 +1,208 @@
+name: VLLM Benchmark
+
+on:
+  schedule:
+    # Run every 6 hours (4 times a day)
+    - cron: '0 */6 * * *'
+  workflow_dispatch:  # Allow manual triggering
+  pull_request:
+    paths:
+      - .github/workflows/vllm-benchmark.yml
+
+jobs:
+  benchmark-h100:
+    name: Run vLLM benchmarks
+    runs-on: linux.aws.h100.4
+    secrets: inherit
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout vLLM repository
+        uses: actions/checkout@v4
+        with:
+          repository: vllm-project/vllm
+          path: vllm-benchmarks/vllm
+          ref: main
+
+      - name: Setup benchmark tests
+        working-directory: vllm-benchmarks
+        run: |
+          # Set the list of benchmarks we want to cover in PyTorch infra
+          cp -r benchmarks/*.json vllm/.buildkite/nightly-benchmarks/tests
+
+      - name: Set GPU device name
+        working-directory: vllm-benchmarks
+        run: |
+          export GPU_DEVICE=$(nvidia-smi -i 0 --query-gpu=name --format=csv,noheader | awk '{print $2}')
+          echo "GPU_DEVICE=$GPU_DEVICE" >> $GITHUB_ENV
+
+      - name: Check for last benchmark commit
+        working-directory: vllm-benchmarks
+        run: |
+          HEAD_BRANCH=main
+
+          # Get the last green commit from S3
+          S3_PATH="last-green-commits/vllm-project/vllm/${HEAD_BRANCH}/${GPU_DEVICE}/commit"
+          NOT_EXIST=0
+          aws s3api head-object --bucket ossci-benchmarks --key ${S3_PATH} || NOT_EXIST=1
+
+          if [[ ${NOT_EXIST} == "0" ]]; then
+            aws s3 cp "s3://ossci-benchmarks/${S3_PATH}" .
+            LAST_GREEN_COMMIT=$(cat commit)
+            echo "LAST_GREEN_COMMIT=$LAST_GREEN_COMMIT" >> $GITHUB_ENV
+          else
+            echo "LAST_GREEN_COMMIT=none" >> $GITHUB_ENV
+          fi
+
+          pushd vllm
+          HEAD_SHA=$(git rev-parse --verify HEAD)
+          popd
+
+          echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_ENV
+
+      - name: Setup GPU_FLAG for docker run
+        run: |
+          echo "GPU_FLAG=--gpus all -e NVIDIA_DRIVER_CAPABILITIES=all" >> "${GITHUB_ENV}"
+
+      - name: Setup SCCACHE_SERVER_PORT environment for docker run when on container
+        run: |
+          echo "SCCACHE_SERVER_PORT_DOCKER_FLAG=-e SCCACHE_SERVER_PORT=$((RUNNER_UID + 4226))" >> "${GITHUB_ENV}"
+
+      - name: Run vLLM benchmark
+        if: env.LAST_GREEN_COMMIT == 'none'
+        shell: bash
+        env:
+          SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
+          SCCACHE_REGION: us-east-1
+          HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+          DOCKER_IMAGE: public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:${{ env.HEAD_SHA }}
+        run:
+          set -eux
+
+          container_name=$(docker run \
+            ${GPU_FLAG:-} \
+            ${SCCACHE_SERVER_PORT_DOCKER_FLAG:-} \
+            -e SCCACHE_BUCKET \
+            -e SCCACHE_REGION \
+            -e HUGGING_FACE_HUB_TOKEN \
+            --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
+            --security-opt seccomp=unconfined \
+            --cap-add=SYS_PTRACE \
+            --ipc=host \
+            --tty \
+            --detach \
+            --name="${container_name}" \
+            -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
+            -w /var/lib/jenkins/workspace \
+            "${DOCKER_IMAGE}"
+          )
+
+          docker exec -t "${container_name}" sh -c "ls -la"
+
+#      - name: Setup Python
+#        uses: actions/setup-python@v5
+#        with:
+#          python-version: '3.12'
+#          cache: 'pip'
+#
+#      - name: Install dependencies
+#        working-directory: vllm-benchmarks
+#        run: |
+#          pip install -r requirements.txt
+#
+#      - name: Setup benchmark tests
+#        working-directory: vllm-benchmarks
+#        run: |
+#          # Set the list of benchmarks we want to cover in PyTorch infra
+#          cp -r benchmarks/*.json vllm/.buildkite/nightly-benchmarks/tests
+#
+#      - name: Set GPU device name
+#        working-directory: vllm-benchmarks
+#        run: |
+#          export GPU_DEVICE=$(nvidia-smi -i 0 --query-gpu=name --format=csv,noheader | awk '{print $2}')
+#          echo "GPU_DEVICE=$GPU_DEVICE" >> $GITHUB_ENV
+#
+#      - name: Check for last benchmark commit
+#        working-directory: vllm-benchmarks
+#        run: |
+#          HEAD_BRANCH=main
+#
+#          # Get the last green commit from S3
+#          S3_PATH="last-green-commits/vllm-project/vllm/${HEAD_BRANCH}/${GPU_DEVICE}/commit"
+#          NOT_EXIST=0
+#          aws s3api head-object --bucket ossci-benchmarks --key ${S3_PATH} || NOT_EXIST=1
+#
+#          if [[ ${NOT_EXIST} == "0" ]]; then
+#            aws s3 cp "s3://ossci-benchmarks/${S3_PATH}" .
+#            LAST_GREEN_COMMIT=$(cat commit)
+#            echo "LAST_GREEN_COMMIT=$LAST_GREEN_COMMIT" >> $GITHUB_ENV
+#          else
+#            echo "LAST_GREEN_COMMIT=none" >> $GITHUB_ENV
+#          fi
+#
+#          pushd vllm
+#          HEAD_SHA=$(git rev-parse --verify HEAD)
+#          popd
+#
+#          echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_ENV
+#
+#      - name: Run benchmarks for latest commit
+#        if: env.LAST_GREEN_COMMIT == 'none'
+#        working-directory: vllm-benchmarks
+#        run: |
+#          set -eux
+#
+#          # Run benchmark for current HEAD
+#          ./run.sh ${{ env.HEAD_SHA }}
+#
+#          # Update last green commit
+#          S3_PATH="v3/vllm-project/vllm/main/${{ env.HEAD_SHA }}/${GPU_DEVICE}/benchmark_results.json"
+#          NOT_EXIST=1
+#          aws s3api head-object --bucket ossci-benchmarks --key ${S3_PATH} || NOT_EXIST=0
+#
+#          if [[ ${NOT_EXIST} == "1" ]]; then
+#            echo "${{ env.HEAD_SHA }}" > commit
+#            echo "Mark ${{ env.HEAD_SHA }} as the latest commit that has been benchmarked on main"
+#
+#            S3_PATH="last-green-commits/vllm-project/vllm/main/${GPU_DEVICE}/commit"
+#            aws s3 cp commit "s3://ossci-benchmarks/${S3_PATH}"
+#          fi
+
+#      - name: Get new commits to benchmark
+#        if: env.LAST_GREEN_COMMIT != 'none' && env.LAST_GREEN_COMMIT != env.HEAD_SHA
+#        id: get-commits
+#        working-directory: vllm-benchmarks
+#        run: |
+#          COMMITS=$(python get_commits.py --repo vllm --from-commit ${{ env.LAST_GREEN_COMMIT }})
+#          echo "COMMITS<<EOF" >> $GITHUB_OUTPUT
+#          echo "$COMMITS" >> $GITHUB_OUTPUT
+#          echo "EOF" >> $GITHUB_OUTPUT
+#
+#      - name: Run benchmarks for new commits
+#        if: env.LAST_GREEN_COMMIT != 'none' && env.LAST_GREEN_COMMIT != env.HEAD_SHA
+#        working-directory: vllm-benchmarks
+#        run: |
+#          # Process each commit
+#          echo "${{ steps.get-commits.outputs.COMMITS }}" | while IFS= read -r COMMIT ; do
+#            # Checkout this specific commit
+#            pushd vllm
+#            git checkout ${COMMIT}
+#            popd
+#
+#            # Run benchmark
+#            ./run.sh ${COMMIT}
+#
+#            # Check if benchmark results exist and update last green commit
+#            S3_PATH="v3/vllm-project/vllm/main/${COMMIT}/${GPU_DEVICE}/benchmark_results.json"
+#            NOT_EXIST=1
+#            aws s3api head-object --bucket ossci-benchmarks --key ${S3_PATH} || NOT_EXIST=0
+#
+#            if [[ ${NOT_EXIST} == "1" ]]; then
+#              echo "${COMMIT}" > commit
+#              echo "Mark ${COMMIT} as the latest commit that has been benchmarked on main"
+#
+#              S3_PATH="last-green-commits/vllm-project/vllm/main/${GPU_DEVICE}/commit"
+#              aws s3 cp commit "s3://ossci-benchmarks/${S3_PATH}"
+#            fi
+#          done

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -5,6 +5,14 @@ on:
     # Run every 2 hours
     - cron: '0 */2 * * *'
   workflow_dispatch:
+    inputs:
+      vllm_branch:
+        required: true
+        type: string
+        default: main
+      vllm_commit:
+        required: false
+        type: string
   pull_request:
     paths:
       - .github/workflows/vllm-benchmark.yml
@@ -27,7 +35,7 @@ jobs:
         with:
           repository: vllm-project/vllm
           path: vllm-benchmarks/vllm
-          ref: main
+          ref: ${{ inputs.vllm_branch || 'main' }}
           fetch-depth: 0
 
       - uses: actions/setup-python@v5
@@ -50,35 +58,38 @@ jobs:
       - name: Check for last benchmark commit
         working-directory: vllm-benchmarks
         env:
-          HEAD_BRANCH: main
+          HEAD_BRANCH: ${{ inputs.vllm_branch || 'main' }}
+          HEAD_SHA: ${{ inputs.vllm_commit || '' }}
           DOCKER_IMAGE_PREFIX: public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo
         run: |
           set -eux
 
-          pushd vllm
-          # Looking back the latest 100 commits is enough
-          for i in {0..99}
-          do
-            # Check if the image is there, if it doesn't then check an older one
-            # because the commit is too recent
-            HEAD_SHA=$(git rev-parse --verify HEAD~${i})
-            DOCKER_IMAGE="${DOCKER_IMAGE_PREFIX}:${HEAD_SHA}"
+          if [[ -z "${HEAD_SHA}" ]]; then
+            pushd vllm
+            # Looking back the latest 100 commits is enough
+            for i in {0..99}
+            do
+              # Check if the image is there, if it doesn't then check an older one
+              # because the commit is too recent
+              HEAD_SHA=$(git rev-parse --verify HEAD~${i})
+              DOCKER_IMAGE="${DOCKER_IMAGE_PREFIX}:${HEAD_SHA}"
 
-            # No Docker image available yet because the commit is too recent
-            if ! docker manifest inspect "${DOCKER_IMAGE}"; then
-              continue
-            fi
+              # No Docker image available yet because the commit is too recent
+              if ! docker manifest inspect "${DOCKER_IMAGE}"; then
+                continue
+              fi
 
-            NOT_EXIST=0
-            S3_PATH="v3/vllm-project/vllm/${HEAD_BRANCH}/${HEAD_SHA}/${GPU_DEVICE}/benchmark_results.json"
-            aws s3api head-object --bucket ossci-benchmarks --key ${S3_PATH} || NOT_EXIST=1
+              NOT_EXIST=0
+              S3_PATH="v3/vllm-project/vllm/${HEAD_BRANCH}/${HEAD_SHA}/${GPU_DEVICE}/benchmark_results.json"
+              aws s3api head-object --bucket ossci-benchmarks --key ${S3_PATH} || NOT_EXIST=1
 
-            if [[ ${NOT_EXIST} == "1" ]]; then
-              echo "Found a vLLM commit ${HEAD_SHA} that hasn't been benchmarked yet"
-              break
-            fi
-          done
-          popd
+              if [[ ${NOT_EXIST} == "1" ]]; then
+                echo "Found a vLLM commit ${HEAD_SHA} that hasn't been benchmarked yet"
+                break
+              fi
+            done
+            popd
+          fi
 
           echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_ENV
 
@@ -133,7 +144,6 @@ jobs:
         working-directory: vllm-benchmarks
         env:
           BENCHMARK_RESULTS: vllm/benchmarks/results
-          HEAD_BRANCH: main
         run: |
           set -eux
 

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -82,7 +82,7 @@ jobs:
         run:
           set -x
 
-          container_name=$(docker run \
+          docker run \
             ${GPU_FLAG:-} \
             ${SCCACHE_SERVER_PORT_DOCKER_FLAG:-} \
             -e SCCACHE_BUCKET \
@@ -96,10 +96,7 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/tmp/workspace" \
             -w /tmp/workspace \
             "${DOCKER_IMAGE}" \
-            ""
-          )
-
-          docker exec -t "${container_name}" sh -c "ls -la"
+            "ls -la"
 
 #      - name: Setup Python
 #        uses: actions/setup-python@v5

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -82,8 +82,7 @@ jobs:
         run:
           set -x
 
-          docker run \
-            ${GPU_FLAG:-} \
+          docker run --gpus all -e NVIDIA_DRIVER_CAPABILITIES=all
             "${DOCKER_IMAGE}" \
             "ls -la"
 

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -95,7 +95,6 @@ jobs:
             --ipc=host \
             --tty \
             --detach \
-            --name="${container_name}" \
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}"

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -65,20 +65,5 @@ jobs:
         run:
           set -x
 
-          docker run --gpus all -e NVIDIA_DRIVER_CAPABILITIES=all "${DOCKER_IMAGE}" bash -xc "ls -la"
-
-
-#            ${SCCACHE_SERVER_PORT_DOCKER_FLAG:-} \
-#            -e SCCACHE_BUCKET \
-#            -e SCCACHE_REGION \
-#            -e GPU_DEVICE \
-#            -e HUGGING_FACE_HUB_TOKEN \
-#            --security-opt seccomp=unconfined \
-#            --cap-add=SYS_PTRACE \
-#            --ipc=host \
-#            --tty \
-#            --detach \
-#            -v "${GITHUB_WORKSPACE}:/tmp/workspace" \
-#            -w /tmp/workspace \
-#            "${DOCKER_IMAGE}" \
-#            "ls -la"
+          # TODO(huydhn): I don't know why backlash doesn't work here
+          docker run ${GPU_FLAG:-} ${SCCACHE_SERVER_PORT_DOCKER_FLAG:-} -e SCCACHE_BUCKET -e SCCACHE_REGION -e GPU_DEVICE -e HUGGING_FACE_HUB_TOKEN --ipc=host --tty --security-opt seccomp=unconfined -v "${GITHUB_WORKSPACE}:/tmp/workspace" -w /tmp/workspace "${DOCKER_IMAGE}" bash -xc "ls -la"

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -62,8 +62,20 @@ jobs:
           SCCACHE_REGION: us-east-1
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
           DOCKER_IMAGE: public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:${{ env.HEAD_SHA }}
-        run:
+        run: |
           set -x
 
-          # TODO(huydhn): I don't know why backlash doesn't work here
-          docker run ${GPU_FLAG:-} ${SCCACHE_SERVER_PORT_DOCKER_FLAG:-} -e SCCACHE_BUCKET -e SCCACHE_REGION -e GPU_DEVICE -e HUGGING_FACE_HUB_TOKEN --ipc=host --tty -v "${GITHUB_WORKSPACE}:/tmp/workspace" -w /tmp/workspace "${DOCKER_IMAGE}" bash -xc "ls -la"
+          docker run \
+            ${GPU_FLAG:-} \
+            ${SCCACHE_SERVER_PORT_DOCKER_FLAG:-} \
+            -e SCCACHE_BUCKET \
+            -e SCCACHE_REGION \
+            -e GPU_DEVICE \
+            -e HUGGING_FACE_HUB_TOKEN \
+            --ipc=host \
+            --tty \
+            --security-opt seccomp=unconfined \
+            -v "${GITHUB_WORKSPACE}:/tmp/workspace" \
+            -w /tmp/workspace \
+            "${DOCKER_IMAGE}" \
+            bash -xc "ls -la"

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -36,6 +36,12 @@ jobs:
           export GPU_DEVICE=$(nvidia-smi -i 0 --query-gpu=name --format=csv,noheader | awk '{print $2}')
           echo "GPU_DEVICE=$GPU_DEVICE" >> $GITHUB_ENV
 
+      - name: Install dependencies
+        working-directory: vllm-benchmarks
+        run: |
+          set -eux
+          pip install -r requirements.txt
+
       - name: Check for last benchmark commit
         working-directory: vllm-benchmarks
         env:
@@ -43,8 +49,6 @@ jobs:
           DOCKER_IMAGE_PREFIX: public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo
         run: |
           set -eux
-
-          pip install awscli
 
           pushd vllm
           # Looking back the latest 100 commits is enough

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -50,13 +50,15 @@ jobs:
           HEAD_BRANCH=main
 
           pushd vllm
-          # Looking back the latest 100 commits is probably enough
+          # Looking back the latest 100 commits is enough
           for i in {0..99}
           do
-            # Check if image already exists, if it does then check an older one
+            # Check if the image is there, if it doesn't then check an older one
+            # because the commit is too recent
             HEAD_SHA=$(git rev-parse --verify HEAD~${i})
             DOCKER_IMAGE="${DOCKER_IMAGE_PREFIX}:${HEAD_SHA}"
 
+            # TODO: SKIP COMMIT THAT HAS ALREADY BEEN RUN
             if docker manifest inspect "${DOCKER_IMAGE}"; then
               break
             fi
@@ -88,7 +90,6 @@ jobs:
           docker run \
             ${GPU_FLAG:-} \
             ${SCCACHE_SERVER_PORT_DOCKER_FLAG:-} \
-            -u "${UID}" \
             -e SCCACHE_BUCKET \
             -e SCCACHE_REGION \
             -e GPU_DEVICE \
@@ -99,4 +100,12 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/tmp/workspace" \
             -w /tmp/workspace \
             "${DOCKER_IMAGE}" \
-            bash -xc "cd vllm-benchmarks/vllm && bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh && ls -lah benchmarks/results"
+            bash -xc "cd vllm-benchmarks/vllm && bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh"
+
+      - name: Upload the benchmark results
+        working-directory: vllm-benchmarks
+        run: |
+          set -eux
+
+          sudo chown ${UID} vllm/benchmarks/results
+          ls -lah vllm/benchmarks/results

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -89,14 +89,13 @@ jobs:
             -e SCCACHE_BUCKET \
             -e SCCACHE_REGION \
             -e HUGGING_FACE_HUB_TOKEN \
-            --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
             --security-opt seccomp=unconfined \
             --cap-add=SYS_PTRACE \
             --ipc=host \
             --tty \
             --detach \
-            -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
-            -w /var/lib/jenkins/workspace \
+            -v "${GITHUB_WORKSPACE}:/tmp/workspace" \
+            -w /tmp/workspace \
             "${DOCKER_IMAGE}"
           )
 

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -42,22 +42,6 @@ jobs:
         run: |
           HEAD_BRANCH=main
 
-          # Get the last green commit from S3
-          # S3_PATH="last-green-commits/vllm-project/vllm/${HEAD_BRANCH}/${GPU_DEVICE}/commit"
-          # NOT_EXIST=0
-          # aws s3api head-object --bucket ossci-benchmarks --key ${S3_PATH} || NOT_EXIST=1
-
-          # if [[ ${NOT_EXIST} == "0" ]]; then
-          #   aws s3 cp "s3://ossci-benchmarks/${S3_PATH}" .
-          #   LAST_GREEN_COMMIT=$(cat commit)
-          #   echo "LAST_GREEN_COMMIT=$LAST_GREEN_COMMIT" >> $GITHUB_ENV
-          # else
-          #   echo "LAST_GREEN_COMMIT=none" >> $GITHUB_ENV
-          # fi
-
-          # DEBUG
-          echo "LAST_GREEN_COMMIT=none" >> $GITHUB_ENV
-
           pushd vllm
           HEAD_SHA=$(git rev-parse --verify HEAD)
           popd
@@ -73,7 +57,6 @@ jobs:
           echo "SCCACHE_SERVER_PORT_DOCKER_FLAG=-e SCCACHE_SERVER_PORT=$((RUNNER_UID + 4226))" >> "${GITHUB_ENV}"
 
       - name: Run vLLM benchmark
-        if: env.LAST_GREEN_COMMIT == 'none'
         env:
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
           SCCACHE_REGION: us-east-1
@@ -82,14 +65,17 @@ jobs:
         run:
           set -x
 
-          docker run --gpus all -e NVIDIA_DRIVER_CAPABILITIES=all
+          docker run \
+            --gpus all \
+            -e NVIDIA_DRIVER_CAPABILITIES=all \
             "${DOCKER_IMAGE}" \
-            "ls -la"
+            bash -xc "ls -la"
 
 
 #            ${SCCACHE_SERVER_PORT_DOCKER_FLAG:-} \
 #            -e SCCACHE_BUCKET \
 #            -e SCCACHE_REGION \
+#            -e GPU_DEVICE \
 #            -e HUGGING_FACE_HUB_TOKEN \
 #            --security-opt seccomp=unconfined \
 #            --cap-add=SYS_PTRACE \
@@ -100,110 +86,3 @@ jobs:
 #            -w /tmp/workspace \
 #            "${DOCKER_IMAGE}" \
 #            "ls -la"
-
-#      - name: Setup Python
-#        uses: actions/setup-python@v5
-#        with:
-#          python-version: '3.12'
-#          cache: 'pip'
-#
-#      - name: Install dependencies
-#        working-directory: vllm-benchmarks
-#        run: |
-#          pip install -r requirements.txt
-#
-#      - name: Setup benchmark tests
-#        working-directory: vllm-benchmarks
-#        run: |
-#          # Set the list of benchmarks we want to cover in PyTorch infra
-#          cp -r benchmarks/*.json vllm/.buildkite/nightly-benchmarks/tests
-#
-#      - name: Set GPU device name
-#        working-directory: vllm-benchmarks
-#        run: |
-#          export GPU_DEVICE=$(nvidia-smi -i 0 --query-gpu=name --format=csv,noheader | awk '{print $2}')
-#          echo "GPU_DEVICE=$GPU_DEVICE" >> $GITHUB_ENV
-#
-#      - name: Check for last benchmark commit
-#        working-directory: vllm-benchmarks
-#        run: |
-#          HEAD_BRANCH=main
-#
-#          # Get the last green commit from S3
-#          S3_PATH="last-green-commits/vllm-project/vllm/${HEAD_BRANCH}/${GPU_DEVICE}/commit"
-#          NOT_EXIST=0
-#          aws s3api head-object --bucket ossci-benchmarks --key ${S3_PATH} || NOT_EXIST=1
-#
-#          if [[ ${NOT_EXIST} == "0" ]]; then
-#            aws s3 cp "s3://ossci-benchmarks/${S3_PATH}" .
-#            LAST_GREEN_COMMIT=$(cat commit)
-#            echo "LAST_GREEN_COMMIT=$LAST_GREEN_COMMIT" >> $GITHUB_ENV
-#          else
-#            echo "LAST_GREEN_COMMIT=none" >> $GITHUB_ENV
-#          fi
-#
-#          pushd vllm
-#          HEAD_SHA=$(git rev-parse --verify HEAD)
-#          popd
-#
-#          echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_ENV
-#
-#      - name: Run benchmarks for latest commit
-#        if: env.LAST_GREEN_COMMIT == 'none'
-#        working-directory: vllm-benchmarks
-#        run: |
-#          set -eux
-#
-#          # Run benchmark for current HEAD
-#          ./run.sh ${{ env.HEAD_SHA }}
-#
-#          # Update last green commit
-#          S3_PATH="v3/vllm-project/vllm/main/${{ env.HEAD_SHA }}/${GPU_DEVICE}/benchmark_results.json"
-#          NOT_EXIST=1
-#          aws s3api head-object --bucket ossci-benchmarks --key ${S3_PATH} || NOT_EXIST=0
-#
-#          if [[ ${NOT_EXIST} == "1" ]]; then
-#            echo "${{ env.HEAD_SHA }}" > commit
-#            echo "Mark ${{ env.HEAD_SHA }} as the latest commit that has been benchmarked on main"
-#
-#            S3_PATH="last-green-commits/vllm-project/vllm/main/${GPU_DEVICE}/commit"
-#            aws s3 cp commit "s3://ossci-benchmarks/${S3_PATH}"
-#          fi
-
-#      - name: Get new commits to benchmark
-#        if: env.LAST_GREEN_COMMIT != 'none' && env.LAST_GREEN_COMMIT != env.HEAD_SHA
-#        id: get-commits
-#        working-directory: vllm-benchmarks
-#        run: |
-#          COMMITS=$(python get_commits.py --repo vllm --from-commit ${{ env.LAST_GREEN_COMMIT }})
-#          echo "COMMITS<<EOF" >> $GITHUB_OUTPUT
-#          echo "$COMMITS" >> $GITHUB_OUTPUT
-#          echo "EOF" >> $GITHUB_OUTPUT
-#
-#      - name: Run benchmarks for new commits
-#        if: env.LAST_GREEN_COMMIT != 'none' && env.LAST_GREEN_COMMIT != env.HEAD_SHA
-#        working-directory: vllm-benchmarks
-#        run: |
-#          # Process each commit
-#          echo "${{ steps.get-commits.outputs.COMMITS }}" | while IFS= read -r COMMIT ; do
-#            # Checkout this specific commit
-#            pushd vllm
-#            git checkout ${COMMIT}
-#            popd
-#
-#            # Run benchmark
-#            ./run.sh ${COMMIT}
-#
-#            # Check if benchmark results exist and update last green commit
-#            S3_PATH="v3/vllm-project/vllm/main/${COMMIT}/${GPU_DEVICE}/benchmark_results.json"
-#            NOT_EXIST=1
-#            aws s3api head-object --bucket ossci-benchmarks --key ${S3_PATH} || NOT_EXIST=0
-#
-#            if [[ ${NOT_EXIST} == "1" ]]; then
-#              echo "${COMMIT}" > commit
-#              echo "Mark ${COMMIT} as the latest commit that has been benchmarked on main"
-#
-#              S3_PATH="last-green-commits/vllm-project/vllm/main/${GPU_DEVICE}/commit"
-#              aws s3 cp commit "s3://ossci-benchmarks/${S3_PATH}"
-#            fi
-#          done

--- a/vllm-benchmarks/requirements.txt
+++ b/vllm-benchmarks/requirements.txt
@@ -4,3 +4,4 @@ psutil==7.0.0
 pynvml==12.0.0
 boto3==1.36.21
 awscli==1.37.21
+torch==2.7.0

--- a/vllm-benchmarks/upload_benchmark_results.py
+++ b/vllm-benchmarks/upload_benchmark_results.py
@@ -44,7 +44,6 @@ def parse_args() -> Any:
     vllm_metadata.add_argument(
         "--vllm",
         type=str,
-        required=True,
         action=ValidateDir,
         help="the directory that vllm repo is checked out",
     )
@@ -58,7 +57,6 @@ def parse_args() -> Any:
     branch_commit.add_argument(
         "--head-sha",
         type=str,
-        required=True,
         help="the commit SHA the benchmark runs on",
     )
     parser.add_argument(
@@ -123,6 +121,8 @@ def get_runner_info() -> Dict[str, Any]:
         name = "rocm"
     elif torch.cuda.is_available() and torch.version.cuda:
         name = "cuda"
+    else:
+        name = "unknown"
 
     return {
         "name": name,

--- a/vllm-benchmarks/upload_benchmark_results.py
+++ b/vllm-benchmarks/upload_benchmark_results.py
@@ -195,7 +195,6 @@ def upload_to_s3(
             f"{s3_bucket}",
             f"{s3_path}",
         ).put(
-            ACL="public-read",
             Body=gzip.compress(data.encode()),
             ContentEncoding="gzip",
             ContentType="application/json",


### PR DESCRIPTION
The new workflow can be run periodically every 2 hours or on demand by setting the commit from vLLM main branch to benchmark.  It works as follows:

1.  When schedule, the workflow checks the latest commits from vLLM main branch chronologically until it finds the latest commit whose vLLM CI Docker image has already been built and has not been benchmarked yet.  The Docker image name is `public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:<SHA>`
2. When running on demand, it will just check for the request Docker image and returns early if that doesn't exist yet
4. The workflows uses the official benchmark scripts from vLLM at https://github.com/vllm-project/vllm/blob/main/.buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
5. Instead of using the list of models from vLLM, we are going to use those from https://github.com/pytorch/pytorch-integration-testing/tree/main/vllm-benchmarks/benchmarks so that we can control exactly what to benchmark
6. 4xH100 currently takes 45 minutes to finish all benchmarks

Some more PRs are coming after this:

* ROCm MI300x benchmark.  I need to figure out the Docker image vLLM uses for this
* Adding Llama 4 Scout and Maverick to https://github.com/pytorch/pytorch-integration-testing/tree/main/vllm-benchmarks/benchmarks

### Testing

The results are showing up on the dashboard now https://hud.pytorch.org/benchmark/llms?startTime=Fri%2C%2023%20May%202025%2019%3A19%3A35%20GMT&stopTime=Fri%2C%2030%20May%202025%2019%3A19%3A35%20GMT&granularity=day&lBranch=main&lCommit=7f21e8052b5f3948c8a59514a8dc1e9c5eef70d6&rBranch=main&rCommit=7f21e8052b5f3948c8a59514a8dc1e9c5eef70d6&repoName=vllm-project%2Fvllm&benchmarkName=&modelName=All%20Models&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=All%20Devices&archName=All%20Platforms