### PR TITLE
Fix lowercase bug in setup benchmark script

### DIFF
--- a/.github/scripts/setup_vllm_benchmark.py
+++ b/.github/scripts/setup_vllm_benchmark.py
@@ -90,7 +90,7 @@ def setup_benchmark_configs(
             if "model" not in benchmark_config:
                 warning(f"Model name is not set in {benchmark_config}, skipping...")
                 continue
-            model = benchmark_config["model"]
+            model = benchmark_config["model"].lower()
 
             if model not in models:
                 continue


### PR DESCRIPTION
I miss a bug in https://github.com/pytorch/pytorch-integration-testing/pull/33.  The generation script uses lowercase so the setup script needs to do the same