### PR TITLE
Extend the upload script for other local use cases

### DIFF
--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -199,7 +199,8 @@ jobs:
           ls -lah "${BENCHMARK_RESULTS}"
 
           python upload_benchmark_results.py \
-            --vllm vllm \
+            --repo vllm \
+            --benchmark-name "vLLM benchmark" \
             --benchmark-results "${BENCHMARK_RESULTS}" \
             --device "${GPU_DEVICE}" \
             --model "${MODELS//\//_}"

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -203,4 +203,5 @@ jobs:
             --benchmark-name "vLLM benchmark" \
             --benchmark-results "${BENCHMARK_RESULTS}" \
             --device "${GPU_DEVICE}" \
+            --s3-bucket ossci-benchmarks \
             --model "${MODELS//\//_}"

--- a/vllm-benchmarks/upload_benchmark_results.py
+++ b/vllm-benchmarks/upload_benchmark_results.py
@@ -311,7 +311,7 @@ def upload(
         if s3_bucket:
             upload_s3(s3_bucket, s3_path, data)
         elif upload_url:
-            upload_via_api(upload_url, data)
+            upload_via_api(upload_url, s3_path, data)
 
 
 def main() -> None:

--- a/vllm-benchmarks/upload_benchmark_results.py
+++ b/vllm-benchmarks/upload_benchmark_results.py
@@ -23,7 +23,7 @@ from git import Repo
 logging.basicConfig(level=logging.INFO)
 
 S3_BUCKET = "ossci-benchmarks"
-UPLOADER_URL = "https://qrr6jzjpvyyd77fkj6mqkes4mq0tpirr.lambda-url.us-east-1.on.aws"
+UPLOADER_URL = "https://kvvka55vt7t2dzl6qlxys72kra0xtirv.lambda-url.us-east-1.on.aws"
 UPLOADER_USERNAME = os.environ.get("UPLOADER_USERNAME")
 UPLOADER_PASSWORD = os.environ.get("UPLOADER_PASSWORD")
 


### PR DESCRIPTION
This is the script I'm using to upload vLLM benchmark results.  It can be retrofit to upload other benchmark results too, for example `torch.compile` benchmark results on GB200.  I will write a wiki on how to use this script, but the simple usage is:

```
UPLOADER_USERNAME=<REACT>
UPLOADER_PASSWORD=<REACT>
GPU_DEVICE=$(nvidia-smi -i 0 --query-gpu=name --format=csv,noheader | awk '{print $2}')

python upload_benchmark_results.py \
  --repo pytorch \
  --benchmark-name TorchInductor \
  --benchmark-results test-reports \
  --device "${GPU_DEVICE}" \
  --dry-run
```

This also handles JSONEachRow format correctly in `read_benchmark_results` function as this is the format used by ClickHouse and DynamoBench

cc @zhe-thoughts @ZainRizvi