### PR TITLE
Fix wrong repo name

### DIFF
--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -161,6 +161,8 @@ jobs:
           find .buildkite/nightly-benchmarks/tests -type f -exec cat {} \;
           popd
 
+          sleep 3600
+
       - name: Run vLLM benchmark
         env:
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -23,7 +23,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/vllm-benchmark.yml
-      - vllm-benchmarks/benchmarks/**
+      - vllm-benchmarks/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -161,8 +161,6 @@ jobs:
           find .buildkite/nightly-benchmarks/tests -type f -exec cat {} \;
           popd
 
-          sleep 3600
-
       - name: Run vLLM benchmark
         env:
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2

--- a/vllm-benchmarks/upload_benchmark_results.py
+++ b/vllm-benchmarks/upload_benchmark_results.py
@@ -111,8 +111,9 @@ def parse_args() -> Any:
 
 def get_git_metadata(repo_dir: str) -> Tuple[str, str]:
     repo = Repo(repo_dir)
-    # Git metadata
-    repo_name = repo.remotes.origin.url.split(".git")[0].split(":")[-1]
+    # Git metadata, an example remote URL is https://github.com/vllm-project/vllm.git
+    # and we want the vllm-project/vllm part
+    repo_name = repo.remotes.origin.url.split(".git")[0].replace("https://github.com/", "")
     hexsha = repo.head.object.hexsha
     committed_date = repo.head.object.committed_date
 

--- a/vllm-benchmarks/upload_benchmark_results.py
+++ b/vllm-benchmarks/upload_benchmark_results.py
@@ -308,7 +308,6 @@ def main() -> None:
     metadata = get_benchmark_metadata(
         repo_name, head_branch, head_sha, timestamp, args.benchmark_name
     )
-    print(repo_name)
     runner = get_runner_info()
 
     # Extract and aggregate the benchmark results

--- a/vllm-benchmarks/upload_benchmark_results.py
+++ b/vllm-benchmarks/upload_benchmark_results.py
@@ -307,6 +307,7 @@ def main() -> None:
     metadata = get_benchmark_metadata(
         repo_name, head_branch, head_sha, timestamp, args.benchmark_name
     )
+    print(repo_name)
     runner = get_runner_info()
 
     # Extract and aggregate the benchmark results


### PR DESCRIPTION
A bug from https://github.com/pytorch/pytorch-integration-testing/pull/36.  The upload is fine, but the repo name showing up in the record is wrong.  Instead of `vllm-project/vllm`, it shows up as `github.com/vllm-project/vllm`