### PR TITLE
Fix model selection

### DIFF
--- a/.github/scripts/generate_vllm_benchmark_matrix.py
+++ b/.github/scripts/generate_vllm_benchmark_matrix.py
@@ -76,10 +76,10 @@ def parse_args() -> Any:
         help="the comma-separated list of models to benchmark",
     )
     parser.add_argument(
-        "--platforms",
+        "--gpus",
         type=str,
         default="",
-        help="the comma-separated list of platforms to benchmark",
+        help="the comma-separated list of GPUs to benchmark",
     )
 
     return parser.parse_args()
@@ -107,14 +107,14 @@ def set_output(name: str, val: Any) -> None:
 
 
 def generate_benchmark_matrix(
-    benchmark_configs_dir: str, models: List[str], platforms: List[str]
+    benchmark_configs_dir: str, models: List[str], gpus: List[str]
 ) -> Dict[str, Any]:
     """
     Parse all the JSON files in vLLM benchmark configs directory to get the
     model name and tensor parallel size (aka number of GPUs)
     """
     get_all_models = True if not models else False
-    use_all_platforms = True if not platforms else False
+    use_all_gpus = True if not gpus else False
 
     benchmark_matrix: Dict[str, Any] = {
         "include": [],
@@ -154,12 +154,12 @@ def generate_benchmark_matrix(
 
             for runner in RUNNERS_MAPPING[tp]:
                 found_runner = False
-                for platform in platforms:
-                    if platform in runner:
+                for gpu in gpus:
+                    if gpu.lower() in runner:
                         found_runner = True
                         break
 
-                if found_runner or use_all_platforms:
+                if found_runner or use_all_gpus:
                     benchmark_matrix["include"].append(
                         {
                             "runner": runner,
@@ -175,11 +175,11 @@ def generate_benchmark_matrix(
 def main() -> None:
     args = parse_args()
     models = [m.strip().lower() for m in args.models.split(",") if m.strip()]
-    platforms = [m.strip().lower() for m in args.platforms.split(",") if m.strip()]
+    gpus = [m.strip().lower() for m in args.gpus.split(",") if m.strip()]
     benchmark_matrix = generate_benchmark_matrix(
         args.benchmark_configs_dir,
         models,
-        platforms,
+        gpus,
     )
     set_output("benchmark_matrix", benchmark_matrix)
 

--- a/.github/scripts/generate_vllm_benchmark_matrix.py
+++ b/.github/scripts/generate_vllm_benchmark_matrix.py
@@ -113,13 +113,12 @@ def generate_benchmark_matrix(
     Parse all the JSON files in vLLM benchmark configs directory to get the
     model name and tensor parallel size (aka number of GPUs)
     """
-    get_all_models = True if not models else False
     use_all_gpus = True if not gpus else False
-
     benchmark_matrix: Dict[str, Any] = {
         "include": [],
     }
 
+    selected_models = []
     for file in glob.glob(f"{benchmark_configs_dir}/*.json"):
         with open(file) as f:
             try:
@@ -139,10 +138,12 @@ def generate_benchmark_matrix(
             model = benchmark_config["model"].lower()
 
             # Dedup
-            if model in models:
+            if model in selected_models:
                 continue
-            if get_all_models:
-                models.append(model)
+            # and only choose the selected model:
+            if models and model not in models:
+                continue
+            selected_models.append(model)
 
             if "tensor_parallel_size" in benchmark_config:
                 tp = benchmark_config["tensor_parallel_size"]

--- a/.github/scripts/generate_vllm_benchmark_matrix.py
+++ b/.github/scripts/generate_vllm_benchmark_matrix.py
@@ -149,7 +149,7 @@ def generate_benchmark_matrix(
             for runner in RUNNERS_MAPPING[tp]:
                 found_runner = False
                 for platform in platforms:
-                    if platform in runner
+                    if platform in runner:
                         found_runner = True
                         break
 

--- a/.github/scripts/generate_vllm_benchmark_matrix.py
+++ b/.github/scripts/generate_vllm_benchmark_matrix.py
@@ -78,7 +78,7 @@ def parse_args() -> Any:
     parser.add_argument(
         "--platforms",
         type=str,
-        default="h100,mi300",
+        default="",
         help="the comma-separated list of platforms to benchmark",
     )
 

--- a/.github/scripts/generate_vllm_benchmark_matrix.py
+++ b/.github/scripts/generate_vllm_benchmark_matrix.py
@@ -75,6 +75,12 @@ def parse_args() -> Any:
         default="",
         help="the comma-separated list of models to benchmark",
     )
+    parser.add_argument(
+        "--platforms",
+        type=str,
+        default="h100,mi300",
+        help="the comma-separated list of platforms to benchmark",
+    )
 
     return parser.parse_args()
 

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -98,9 +98,9 @@ jobs:
           if command -v nvidia-smi; then
             PLATFORM=cuda
             nvidia-smi
-          elif command -v amd-smi; then
+          elif command -v rocm-smi; then
             PLATFORM=rocm
-            amd-smi
+            rocm-smi
           else
             echo "Only CUDA and ROCm benchmarks are supported at the moment"
             exit 1

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -20,6 +20,13 @@ on:
           A comma-separated list of models to benchmark, leave empty to run everything
         required: false
         type: string
+      platforms:
+        description: |
+          A comma-separated list of platforms to benchmark, i.e. h100, mi300
+        required: true
+        type: string
+        # default: h100,mi300
+        default: mi300
   pull_request:
     paths:
       - .github/workflows/vllm-benchmark.yml
@@ -47,13 +54,15 @@ jobs:
         shell: bash
         env:
           MODELS: ${{ inputs.models || '' }}
+          PLATFORMS: ${{ inputs.platforms || '' }}
         run: |
           set -eux
 
           # The generated matrix is grouped by model and runner
           python .github/scripts/generate_vllm_benchmark_matrix.py \
             --benchmark-configs-dir vllm-benchmarks/benchmarks \
-            --models "${MODELS}"
+            --models "${MODELS}" \
+            --platforms "${PLATFORMS}"
 
   benchmarks:
     name: Run vLLM benchmarks
@@ -80,23 +89,60 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
+      - name: Check if the platform is supported
+        shell: bash
+        run: |
+          set -eux
+
+          if command -v nvidia-smi; then
+            PLATFORM=cuda
+            nvidia-smi
+          elif command -v amd-smi; then
+            PLATFORM=rocm
+            amd-smi
+          else
+            echo "Only CUDA and ROCm benchmarks are supported at the moment"
+            exit 1
+          fi
+          echo "PLATFORM=$PLATFORM" >> $GITHUB_ENV
+
       - name: Set GPU device name
         working-directory: vllm-benchmarks
+        shell: bash
         run: |
-          export GPU_DEVICE=$(nvidia-smi -i 0 --query-gpu=name --format=csv,noheader | awk '{print $2}')
+          if [[ "${PLATFORM}" == "cuda" ]]; then
+            GPU_DEVICE=$(nvidia-smi -i 0 --query-gpu=name --format=csv,noheader | awk '{print $2}')
+          elif [[ "${PLATFORM}" == "rocm" ]]; then
+            GPU_DEVICE=$(amd-smi static -g 0 -a | grep 'MARKET_NAME' | awk '{print $2}')
+          fi
           echo "GPU_DEVICE=$GPU_DEVICE" >> $GITHUB_ENV
 
       - name: Install dependencies
+        shell: bash
         run: |
           set -eux
-          pip install -r .github/scripts/requirements.txt
+
+          if [[ "${PLATFORM}" == "cuda" ]]; then
+            pip install -r .github/scripts/requirements.txt
+          elif [[ "${PLATFORM}" == "rocm" ]]; then
+            pip install -r .github/scripts/requirements.txt \
+              --extra-index-url https://download.pytorch.org/whl/rocm6.3
+          fi
+
+      - name: Set Docker registry
+        shell: bash
+        run: |
+          if [[ "${PLATFORM}" == "cuda" ]]; then
+            DOCKER_IMAGE_PREFIX=public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo
+          elif [[ "${PLATFORM}" == "rocm" ]]; then
+            DOCKER_IMAGE_PREFIX=docker.io/rocm/vllm-ci
+          fi
 
       - name: Check for last benchmark commit
         working-directory: vllm-benchmarks
         env:
           HEAD_BRANCH: ${{ inputs.vllm_branch || 'main' }}
           HEAD_SHA: ${{ inputs.vllm_commit || '' }}
-          DOCKER_IMAGE_PREFIX: public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo
           MODELS: ${{ matrix.models }}
         run: |
           set -eux
@@ -130,9 +176,14 @@ jobs:
 
           echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_ENV
 
-      - name: Setup GPU_FLAG for docker run
+      - name: Setup CUDA GPU_FLAG for docker run
+        if: env.PLATFORM == 'cuda'
         run: |
           echo "GPU_FLAG=--gpus all -e NVIDIA_DRIVER_CAPABILITIES=all" >> "${GITHUB_ENV}"
+
+      - name: Setup ROCm
+        if: env.PLATFORM == 'rocm'
+        uses: pytorch/pytorch/./.github/actions/setup-rocm@main
 
       - name: Setup SCCACHE_SERVER_PORT environment for docker run when on container
         run: |
@@ -165,7 +216,7 @@ jobs:
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
           SCCACHE_REGION: us-east-1
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          DOCKER_IMAGE: public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:${{ env.HEAD_SHA }}
+          DOCKER_IMAGE: ${{ env.DOCKER_IMAGE_PREFIX }}:${{ env.HEAD_SHA }}
           # vLLM-related environment variables
           ENGINE_VERSION: v1
           SAVE_TO_PYTORCH_BENCHMARK_FORMAT: 1
@@ -205,3 +256,7 @@ jobs:
             --benchmark-results "${BENCHMARK_RESULTS}" \
             --device "${GPU_DEVICE}" \
             --model "${MODELS//\//_}"
+
+      - name: Teardown ROCm
+        if: env.PLATFORM == 'rocm'
+        uses: pytorch/pytorch/./.github/actions/teardown-rocm@main

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -20,9 +20,9 @@ on:
           A comma-separated list of models to benchmark, leave empty to run everything
         required: false
         type: string
-      platforms:
+      gpus:
         description: |
-          A comma-separated list of platforms to benchmark, i.e. h100, mi300
+          A comma-separated list of GPUs to benchmark, i.e. h100, mi300
         required: true
         type: string
         default: h100,mi300
@@ -53,8 +53,7 @@ jobs:
         shell: bash
         env:
           MODELS: ${{ inputs.models || '' }}
-          # DEBUG
-          PLATFORMS: ${{ inputs.platforms || '' }}
+          GPUS: ${{ inputs.gpus || '' }}
         run: |
           set -eux
 
@@ -62,7 +61,7 @@ jobs:
           python .github/scripts/generate_vllm_benchmark_matrix.py \
             --benchmark-configs-dir vllm-benchmarks/benchmarks \
             --models "${MODELS}" \
-            --platforms "${PLATFORMS}"
+            --gpus "${GPUS}"
 
   benchmarks:
     name: Run vLLM benchmarks
@@ -89,22 +88,22 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
-      - name: Check if the platform is supported
+      - name: Check if the device is supported
         shell: bash
         run: |
           set -eux
 
           if command -v nvidia-smi; then
-            PLATFORM=cuda
+            DEVICE=cuda
             nvidia-smi
           elif command -v rocm-smi; then
-            PLATFORM=rocm
+            DEVICE=rocm
             rocm-smi
           else
             echo "Only CUDA and ROCm benchmarks are supported at the moment"
             exit 1
           fi
-          echo "PLATFORM=$PLATFORM" >> $GITHUB_ENV
+          echo "DEVICE=$DEVICE" >> $GITHUB_ENV
 
       - name: Set GPU device name
         working-directory: vllm-benchmarks
@@ -112,9 +111,9 @@ jobs:
         run: |
           set -eux
 
-          if [[ "${PLATFORM}" == "cuda" ]]; then
+          if [[ "${DEVICE}" == "cuda" ]]; then
             GPU_DEVICE=$(nvidia-smi -i 0 --query-gpu=name --format=csv,noheader | awk '{print $2}')
-          elif [[ "${PLATFORM}" == "rocm" ]]; then
+          elif [[ "${DEVICE}" == "rocm" ]]; then
             GPU_DEVICE=$(rocminfo | grep "Marketing Name" | tail -n1 | awk -F':' '{print $2}' | xargs)
           fi
           echo "GPU_DEVICE=$GPU_DEVICE" >> $GITHUB_ENV
@@ -124,9 +123,9 @@ jobs:
         run: |
           set -eux
 
-          if [[ "${PLATFORM}" == "cuda" ]]; then
+          if [[ "${DEVICE}" == "cuda" ]]; then
             pip install -r .github/scripts/requirements.txt
-          elif [[ "${PLATFORM}" == "rocm" ]]; then
+          elif [[ "${DEVICE}" == "rocm" ]]; then
             pip install -r .github/scripts/requirements.txt \
               --extra-index-url https://download.pytorch.org/whl/rocm6.3
           fi
@@ -134,9 +133,9 @@ jobs:
       - name: Set Docker registry
         shell: bash
         run: |
-          if [[ "${PLATFORM}" == "cuda" ]]; then
+          if [[ "${DEVICE}" == "cuda" ]]; then
             DOCKER_IMAGE_PREFIX=public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo
-          elif [[ "${PLATFORM}" == "rocm" ]]; then
+          elif [[ "${DEVICE}" == "rocm" ]]; then
             DOCKER_IMAGE_PREFIX=docker.io/rocm/vllm-ci
           fi
           echo "DOCKER_IMAGE_PREFIX=$DOCKER_IMAGE_PREFIX" >> $GITHUB_ENV
@@ -180,12 +179,12 @@ jobs:
           echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_ENV
 
       - name: Setup CUDA GPU_FLAG for docker run
-        if: env.PLATFORM == 'cuda'
+        if: env.DEVICE == 'cuda'
         run: |
           echo "GPU_FLAG=--gpus all -e NVIDIA_DRIVER_CAPABILITIES=all" >> "${GITHUB_ENV}"
 
       - name: Setup ROCm
-        if: env.PLATFORM == 'rocm'
+        if: env.DEVICE == 'rocm'
         uses: pytorch/pytorch/./.github/actions/setup-rocm@main
 
       - name: Setup SCCACHE_SERVER_PORT environment for docker run when on container
@@ -245,7 +244,7 @@ jobs:
 
       - name: Authenticate with AWS
         # AWS CUDA runners already have access to the bucket via its runner IAM role
-        if: env.PLATFORM != 'cuda'
+        if: env.DEVICE != 'cuda'
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
           role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_upload-benchmark-results
@@ -271,5 +270,5 @@ jobs:
             --model "${MODELS//\//_}"
 
       - name: Teardown ROCm
-        if: env.PLATFORM == 'rocm'
+        if: env.DEVICE == 'rocm'
         uses: pytorch/pytorch/./.github/actions/teardown-rocm@main

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -244,6 +244,16 @@ jobs:
             "${DOCKER_IMAGE}" \
             bash -xc "cd vllm-benchmarks/vllm && bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh"
 
+      - name: Authenticate with AWS
+        # AWS CUDA runners already have access to the bucket via its runner IAM role
+        if: env.PLATFORM != 'cuda'
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_upload-benchmark-results
+          # The max duration enforced by the server side
+          role-duration-seconds: 18000
+          aws-region: us-east-1
+
       - name: Upload the benchmark results
         env:
           BENCHMARK_RESULTS: vllm-benchmarks/vllm/benchmarks/results

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -54,7 +54,8 @@ jobs:
         shell: bash
         env:
           MODELS: ${{ inputs.models || '' }}
-          PLATFORMS: ${{ inputs.platforms || '' }}
+          # DEBUG
+          PLATFORMS: ${{ inputs.platforms || 'mi300' }}
         run: |
           set -eux
 
@@ -110,10 +111,12 @@ jobs:
         working-directory: vllm-benchmarks
         shell: bash
         run: |
+          set -eux
+
           if [[ "${PLATFORM}" == "cuda" ]]; then
             GPU_DEVICE=$(nvidia-smi -i 0 --query-gpu=name --format=csv,noheader | awk '{print $2}')
           elif [[ "${PLATFORM}" == "rocm" ]]; then
-            GPU_DEVICE=$(amd-smi static -g 0 -a | grep 'MARKET_NAME' | awk '{print $2}')
+            GPU_DEVICE=$(rocminfo | grep "Marketing Name" | tail -n1 | awk -F':' '{print $2}' | xargs)
           fi
           echo "GPU_DEVICE=$GPU_DEVICE" >> $GITHUB_ENV
 
@@ -137,6 +140,7 @@ jobs:
           elif [[ "${PLATFORM}" == "rocm" ]]; then
             DOCKER_IMAGE_PREFIX=docker.io/rocm/vllm-ci
           fi
+          echo "DOCKER_IMAGE_PREFIX=$DOCKER_IMAGE_PREFIX" >> $GITHUB_ENV
 
       - name: Check for last benchmark commit
         working-directory: vllm-benchmarks

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -25,8 +25,7 @@ on:
           A comma-separated list of platforms to benchmark, i.e. h100, mi300
         required: true
         type: string
-        # default: h100,mi300
-        default: mi300
+        default: h100,mi300
   pull_request:
     paths:
       - .github/workflows/vllm-benchmark.yml
@@ -55,7 +54,7 @@ jobs:
         env:
           MODELS: ${{ inputs.models || '' }}
           # DEBUG
-          PLATFORMS: ${{ inputs.platforms || 'mi300' }}
+          PLATFORMS: ${{ inputs.platforms || '' }}
         run: |
           set -eux
 

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -97,38 +97,38 @@ jobs:
           set -eux
 
           if command -v nvidia-smi; then
-            DEVICE=cuda
+            DEVICE_NAME=cuda
             nvidia-smi
           elif command -v rocm-smi; then
-            DEVICE=rocm
+            DEVICE_NAME=rocm
             rocm-smi
           else
             echo "Only CUDA and ROCm benchmarks are supported at the moment"
             exit 1
           fi
-          echo "DEVICE=$DEVICE" >> $GITHUB_ENV
+          echo "DEVICE_NAME=$DEVICE_NAME" >> $GITHUB_ENV
 
-      - name: Set GPU device name
+      - name: Set GPU name and type
         working-directory: vllm-benchmarks
         shell: bash
         run: |
           set -eux
 
-          if [[ "${DEVICE}" == "cuda" ]]; then
-            GPU_DEVICE=$(nvidia-smi -i 0 --query-gpu=name --format=csv,noheader | awk '{print $2}')
-          elif [[ "${DEVICE}" == "rocm" ]]; then
-            GPU_DEVICE=$(rocminfo | grep "Marketing Name" | tail -n1 | awk -F':' '{print $2}' | xargs)
+          if [[ "${DEVICE_NAME}" == "cuda" ]]; then
+            DEVICE_TYPE=$(nvidia-smi -i 0 --query-gpu=name --format=csv,noheader | awk '{print $2}')
+          elif [[ "${DEVICE_NAME}" == "rocm" ]]; then
+            DEVICE_TYPE=$(rocminfo | grep "Marketing Name" | tail -n1 | awk -F':' '{print $2}' | xargs)
           fi
-          echo "GPU_DEVICE=$GPU_DEVICE" >> $GITHUB_ENV
+          echo "DEVICE_TYPE=$DEVICE_TYPE" >> $GITHUB_ENV
 
       - name: Install dependencies
         shell: bash
         run: |
           set -eux
 
-          if [[ "${DEVICE}" == "cuda" ]]; then
+          if [[ "${DEVICE_NAME}" == "cuda" ]]; then
             pip install -r .github/scripts/requirements.txt
-          elif [[ "${DEVICE}" == "rocm" ]]; then
+          elif [[ "${DEVICE_NAME}" == "rocm" ]]; then
             pip install -r .github/scripts/requirements.txt \
               --extra-index-url https://download.pytorch.org/whl/rocm6.3
           fi
@@ -136,9 +136,9 @@ jobs:
       - name: Set Docker registry
         shell: bash
         run: |
-          if [[ "${DEVICE}" == "cuda" ]]; then
+          if [[ "${DEVICE_NAME}" == "cuda" ]]; then
             DOCKER_IMAGE_PREFIX=public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo
-          elif [[ "${DEVICE}" == "rocm" ]]; then
+          elif [[ "${DEVICE_NAME}" == "rocm" ]]; then
             DOCKER_IMAGE_PREFIX=docker.io/rocm/vllm-ci
           fi
           echo "DOCKER_IMAGE_PREFIX=$DOCKER_IMAGE_PREFIX" >> $GITHUB_ENV
@@ -168,7 +168,7 @@ jobs:
               fi
 
               NOT_EXIST=0
-              S3_PATH="v3/vllm-project/vllm/${HEAD_BRANCH}/${HEAD_SHA}/${GPU_DEVICE}/benchmark_results_${MODELS//\//_}.json"
+              S3_PATH="v3/vllm-project/vllm/${HEAD_BRANCH}/${HEAD_SHA}/${DEVICE_TYPE// /_}/benchmark_results_${MODELS//\//_}.json"
               aws s3api head-object --bucket ossci-benchmarks --key ${S3_PATH} || NOT_EXIST=1
 
               if [[ ${NOT_EXIST} == "1" ]]; then
@@ -182,12 +182,12 @@ jobs:
           echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_ENV
 
       - name: Setup CUDA GPU_FLAG for docker run
-        if: env.DEVICE == 'cuda'
+        if: env.DEVICE_NAME == 'cuda'
         run: |
           echo "GPU_FLAG=--gpus all -e NVIDIA_DRIVER_CAPABILITIES=all" >> "${GITHUB_ENV}"
 
       - name: Setup ROCm
-        if: env.DEVICE == 'rocm'
+        if: env.DEVICE_NAME == 'rocm'
         uses: pytorch/pytorch/./.github/actions/setup-rocm@main
 
       - name: Setup SCCACHE_SERVER_PORT environment for docker run when on container
@@ -233,7 +233,8 @@ jobs:
             ${SCCACHE_SERVER_PORT_DOCKER_FLAG:-} \
             -e SCCACHE_BUCKET \
             -e SCCACHE_REGION \
-            -e GPU_DEVICE \
+            -e DEVICE_NAME \
+            -e DEVICE_TYPE \
             -e HF_TOKEN \
             -e ENGINE_VERSION \
             -e SAVE_TO_PYTORCH_BENCHMARK_FORMAT \
@@ -247,7 +248,7 @@ jobs:
 
       - name: Authenticate with AWS
         # AWS CUDA runners already have access to the bucket via its runner IAM role
-        if: env.DEVICE != 'cuda'
+        if: env.DEVICE_NAME != 'cuda'
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
           role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_upload-benchmark-results
@@ -269,9 +270,5 @@ jobs:
             --repo vllm-benchmarks/vllm \
             --benchmark-name "vLLM benchmark" \
             --benchmark-results "${BENCHMARK_RESULTS}" \
-            --device "${GPU_DEVICE}" \
+            --device "${DEVICE_TYPE// /_}" \
             --model "${MODELS//\//_}"
-
-      - name: Teardown ROCm
-        if: env.DEVICE == 'rocm'
-        uses: pytorch/pytorch/./.github/actions/teardown-rocm@main

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -71,6 +71,9 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     environment: pytorch-x-vllm
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
There is a bug in the script where I wrongly used `models` variable as both the input list of target models and to de-dup the list of selected models.

### Testing

```
python .github/scripts/generate_vllm_benchmark_matrix.py --benchmark-configs-dir vllm-benchmarks/benchmarks --models "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8" --gpus h100
```

returns only one job now

```
::set-output name=benchmark_matrix::{'include': [{'runner': 'linux.aws.h100.8', 'models': 'meta-llama/llama-4-maverick-17b-128e-instruct-fp8'}]}
```