### PR TITLE
[BE] Update vllm-benchmark parameter descriptions

### DIFF
--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -7,22 +7,22 @@ on:
   workflow_dispatch:
     inputs:
       vllm_branch:
-        description: vLLM branch
+        description: vLLM branch, i.e. main, releases/v0.9.2 for release validation, or refs/pull/PR_NUMBER/head for pre-merge check on pull request
         required: true
         type: string
         default: main
       vllm_commit:
-        description: vLLM commit
+        description: vLLM commit, if not set, default to the latest commit in the branch that has not yet been benchmarked
         required: false
         type: string
       models:
         description: |
-          A comma-separated list of models to benchmark, leave empty to run everything
+          A comma-separated list of models from vllm-benchmarks/benchmarks, leave empty to run everything
         required: false
         type: string
       runners:
         description: |
-          A comma-separated list of runners to run the benchmark, i.e. h100, mi300, spr, emr
+          A comma-separated list of runners from .github/scripts/generate_vllm_benchmark_matrix.py to run the benchmark, i.e. h100, mi300, spr
         required: true
         type: string
         default: h100,mi300,spr

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       vllm_branch:
-        description: vLLM branch (main, releases/v0.9.2 for release validation, or refs/pull/PR_NUMBER/head for pre-merge check on pull request)
+        description: vLLM branch (main, releases/vERSION for release validation, or refs/pull/PR_NUMBER/head for pre-merge check on pull request)
         required: true
         type: string
         default: main

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -7,22 +7,22 @@ on:
   workflow_dispatch:
     inputs:
       vllm_branch:
-        description: vLLM branch, i.e. main, releases/v0.9.2 for release validation, or refs/pull/PR_NUMBER/head for pre-merge check on pull request
+        description: vLLM branch (main, releases/v0.9.2 for release validation, or refs/pull/PR_NUMBER/head for pre-merge check on pull request)
         required: true
         type: string
         default: main
       vllm_commit:
-        description: vLLM commit, if not set, default to the latest commit in the branch that has not yet been benchmarked
+        description: vLLM commit (optional, default to the latest commit in the branch that has not yet been benchmarked)
         required: false
         type: string
       models:
         description: |
-          A comma-separated list of models from vllm-benchmarks/benchmarks, leave empty to run everything
+          A comma-separated list of models from vllm-benchmarks/benchmarks (optional, default to run everything)
         required: false
         type: string
       runners:
         description: |
-          A comma-separated list of runners from .github/scripts/generate_vllm_benchmark_matrix.py to run the benchmark, i.e. h100, mi300, spr
+          A comma-separated list of runners from .github/scripts/generate_vllm_benchmark_matrix.py to run the benchmark (optional, default to run everything)
         required: true
         type: string
         default: h100,mi300,spr


### PR DESCRIPTION
This is a small documentation change to explain how to set these parameters in different use cases.

1. In addition to `main`, `vllm_branch` can be set to the release branch, i.e. `release/v0.9.2` or the pull request in the format `refs/pull/PR_NUMBER/head`.  The latter works with both fork and non-fork PRs.
2. Clarify that if `vllm_commit` is not set, it will be default to the latest commit in the branch that has not yet been benchmarked.
3. Clarify that the model name is defined in `vllm-benchmarks/benchmarks`.  Setting the wrong model name wouldn't run anything.
4. Clarify that the runner name comes from `.github/scripts/generate_vllm_benchmark_matrix.py`.  Again, an invalid runner that is not there wouldn't do anything.

### Testing

<img width="311" height="599" alt="Screenshot 2025-07-16 at 19 02 31" src="https://github.com/user-attachments/assets/da72df77-aa0c-4f0f-8fd4-a171811cd43e" />