### PR TITLE
Fix wrong branch name handling fork PR

### DIFF
--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -53,7 +53,7 @@ jobs:
         shell: bash
         env:
           MODELS: ${{ inputs.models || '' }}
-          RUNNERS: ${{ inputs.runners || 'spr' }}
+          RUNNERS: ${{ inputs.runners || '' }}
         run: |
           set -eux
 


### PR DESCRIPTION
The way to checkout fork PR from vLLM is to use `refs/pull/PR_NUMBER/head`, and as the name implies, the branch name is listed under `refs`.  This was missed by the upload script, so it couldn't find the correct branch name.

### Testing

Run one round of benchmark at https://github.com/pytorch/pytorch-integration-testing/actions/runs/16340432143:
* For https://github.com/vllm-project/vllm/pull/20358 with `refs/pull/20358/head`
* SHA [29fb5a0362035d385640dba240514fc9fa849eab](https://github.com/vllm-project/vllm/pull/20358/commits/29fb5a0362035d385640dba240514fc9fa849eab)

The results are showing up correctly on the [dashboard](https://hud.pytorch.org/benchmark/llms?startTime=Thu%2C%2010%20Jul%202025%2009%3A11%3A54%20GMT&stopTime=Thu%2C%2017%20Jul%202025%2009%3A11%3A54%20GMT&granularity=day&lBranch=main&lCommit=5bac61362b6718b90e708e7b212e7fcbe7d59fa3&rBranch=pull/20358/head&rCommit=29fb5a0362035d385640dba240514fc9fa849eab&repoName=vllm-project%2Fvllm&benchmarkName=&modelName=All%20Models&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=All%20Devices&archName=All%20Platforms) comparing with the PR base commit.  This is also to test vLLM x PyTorch 2.8.0 RC.