### PR TITLE
Run benchmark less frequent (every 4 hours)

### DIFF
--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -2,8 +2,8 @@ name: vLLM Benchmark
 
 on:
   schedule:
-    # Run every 2 hours
-    - cron: '0 */2 * * *'
+    # Run every 4 hours
+    - cron: '0 */4 * * *'
   workflow_dispatch:
     inputs:
       vllm_branch:


### PR DESCRIPTION
`linux.aws.h100.8` couldn't catch up https://github.com/pytorch/pytorch-integration-testing/actions/workflows/vllm-benchmark.yml