### PR TITLE
Run an one-off benchmark for gpt-oss

### DIFF
--- a/.github/scripts/gpt-oss/run_accuracy_checks.sh
+++ b/.github/scripts/gpt-oss/run_accuracy_checks.sh
@@ -44,29 +44,37 @@ mkdir -p /tmp/gpqa_openai
 
 # Not sure why this is needed on ROCm image
 if [[ "${DEVICE_NAME}" == "rocm" ]]; then
-  export PYTHONPATH=$(pwd)
+  pushd gpt_oss
+  # Low
+  OPENAI_API_KEY="" python3 -mevals --base-url http://localhost:8000/v1 \
+    --model $MODEL \
+    --eval gpqa \
+    --reasoning-effort low \
+    --n-threads $(expr $(nproc) / 2)
+  popd
+else
+  sleep 7200
+  # Low
+  #OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
+  #  --model $MODEL \
+  #  --eval gpqa \
+  #  --reasoning-effort low \
+  #  --n-threads $(expr $(nproc) / 2)
+  #
+  # Mid
+  #OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
+  #  --model $MODEL \
+  #  --eval gpqa \
+  #  --reasoning-effort medium \
+  #  --n-threads $(expr $(nproc) / 2)
+  #
+  ## High
+  #OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
+  #  --model $MODEL \
+  #  --eval gpqa \
+  #  --reasoning-effort high \
+  #  --n-threads $(expr $(nproc) / 2)
 fi
-
-# Low
-OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
-  --model $MODEL \
-  --eval gpqa \
-  --reasoning-effort low \
-  --n-threads $(expr $(nproc) / 2)
-
-# Mid
-OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
-  --model $MODEL \
-  --eval gpqa \
-  --reasoning-effort medium \
-  --n-threads $(expr $(nproc) / 2)
-
-# High
-OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
-  --model $MODEL \
-  --eval gpqa \
-  --reasoning-effort high \
-  --n-threads $(expr $(nproc) / 2)
 
 mv /tmp/gpqa_openai .
 popd

--- a/.github/scripts/gpt-oss/run_accuracy_checks.sh
+++ b/.github/scripts/gpt-oss/run_accuracy_checks.sh
@@ -12,6 +12,8 @@ elif [[ "${DEVICE_NAME}" == *rocm* ]]; then
   export VLLM_ROCM_USE_AITER=1
   export VLLM_USE_AITER_UNIFIED_ATTENTION=1
   export VLLM_ROCM_USE_AITER_MHA=0
+else
+  export VLLM_FLASH_ATTN_VERSION=2
 fi
 
 tp=0
@@ -44,9 +46,7 @@ mkdir -p /tmp/gpqa_openai
 
 # Not sure why this is needed on ROCm image
 if [[ "${DEVICE_NAME}" == "rocm" ]]; then
-  ls -la gpt_oss
-  ls -la gpt_oss/evals
-  export PYTHONPATH=$(pwd):$PYTHONPATH
+  export PYTHONPATH=$(pwd)
 fi
 
 # Low

--- a/.github/scripts/gpt-oss/run_accuracy_checks.sh
+++ b/.github/scripts/gpt-oss/run_accuracy_checks.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -eux
+
+tp=0
+if [[ "${MODEL}" == "openai/gpt-oss-120b" ]]; then
+  tp=4
+elif [[ "${MODEL}" == "openai/gpt-oss-20b" ]]; then
+  tp=1
+fi
+
+echo $tp
+# Prepare the accuracy test
+vllm serve $MODEL --tensor_parallel_size $tp &
+server_pid=$!
+
+wait_for_server() {
+  timeout 1200 bash -c '
+    until curl -X POST localhost:8000/v1/completions; do
+      sleep 1
+    done' && return 0 || return 1
+}
+
+if wait_for_server; then
+  echo "vLLM server is up and running"
+else
+  echo "vLLM failed to start within the timeout period"
+fi
+
+pushd vllm-benchmarks/gpt-oss
+mkdir -p /tmp/gpqa_openai
+
+# Low
+OPENAI_API_KEY='' python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
+  --model $MODEL \
+  --eval gpqa \
+  --reasoning-effort low \
+  --n-threads $(expr $(nproc) / 2)
+
+# Mid
+OPENAI_API_KEY='' python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
+  --model $MODEL \
+  --eval gpqa \
+  --reasoning-effort medium \
+  --n-threads $(expr $(nproc) / 2)
+
+# High
+OPENAI_API_KEY='' python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
+  --model $MODEL \
+  --eval gpqa \
+  --reasoning-effort high \
+  --n-threads $(expr $(nproc) / 2)
+
+mv /tmp/gpqa_openai .
+popd
+
+kill -9 $server_pid

--- a/.github/scripts/gpt-oss/run_accuracy_checks.sh
+++ b/.github/scripts/gpt-oss/run_accuracy_checks.sh
@@ -12,8 +12,6 @@ elif [[ "${DEVICE_NAME}" == *rocm* ]]; then
   export VLLM_ROCM_USE_AITER=1
   export VLLM_USE_AITER_UNIFIED_ATTENTION=1
   export VLLM_ROCM_USE_AITER_MHA=0
-else
-  export VLLM_FLASH_ATTN_VERSION=2
 fi
 
 tp=0

--- a/.github/scripts/gpt-oss/run_accuracy_checks.sh
+++ b/.github/scripts/gpt-oss/run_accuracy_checks.sh
@@ -43,13 +43,27 @@ pushd vllm-benchmarks/gpt-oss
 mkdir -p /tmp/gpqa_openai
 
 if [[ "${DEVICE_NAME}" == "rocm" ]]; then
-  # Not sure why this is needed on ROCm image
+  # Not sure why this is needed on ROCm
   pushd gpt_oss
   # Low
   OPENAI_API_KEY="" python3 -mevals --base-url http://localhost:8000/v1 \
     --model $MODEL \
     --eval gpqa \
     --reasoning-effort low \
+    --n-threads $(expr $(nproc) / 2)
+
+  # Mid
+  OPENAI_API_KEY="" python3 -mevals --base-url http://localhost:8000/v1 \
+    --model $MODEL \
+    --eval gpqa \
+    --reasoning-effort medium \
+    --n-threads $(expr $(nproc) / 2)
+
+  # High
+  OPENAI_API_KEY="" python3 -mevals --base-url http://localhost:8000/v1 \
+    --model $MODEL \
+    --eval gpqa \
+    --reasoning-effort high \
     --n-threads $(expr $(nproc) / 2)
   popd
 else
@@ -61,18 +75,18 @@ else
     --n-threads $(expr $(nproc) / 2)
 
   # Mid
-  #OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
-  #  --model $MODEL \
-  #  --eval gpqa \
-  #  --reasoning-effort medium \
-  #  --n-threads $(expr $(nproc) / 2)
-  #
-  ## High
-  #OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
-  #  --model $MODEL \
-  #  --eval gpqa \
-  #  --reasoning-effort high \
-  #  --n-threads $(expr $(nproc) / 2)
+  OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
+    --model $MODEL \
+    --eval gpqa \
+    --reasoning-effort medium \
+    --n-threads $(expr $(nproc) / 2)
+
+  # High
+  OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
+    --model $MODEL \
+    --eval gpqa \
+    --reasoning-effort high \
+    --n-threads $(expr $(nproc) / 2)
 fi
 
 mv /tmp/gpqa_openai .

--- a/.github/scripts/gpt-oss/run_accuracy_checks.sh
+++ b/.github/scripts/gpt-oss/run_accuracy_checks.sh
@@ -42,8 +42,8 @@ fi
 pushd vllm-benchmarks/gpt-oss
 mkdir -p /tmp/gpqa_openai
 
-# Not sure why this is needed on ROCm image
 if [[ "${DEVICE_NAME}" == "rocm" ]]; then
+  # Not sure why this is needed on ROCm image
   pushd gpt_oss
   # Low
   OPENAI_API_KEY="" python3 -mevals --base-url http://localhost:8000/v1 \
@@ -53,14 +53,13 @@ if [[ "${DEVICE_NAME}" == "rocm" ]]; then
     --n-threads $(expr $(nproc) / 2)
   popd
 else
-  sleep 7200
   # Low
-  #OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
-  #  --model $MODEL \
-  #  --eval gpqa \
-  #  --reasoning-effort low \
-  #  --n-threads $(expr $(nproc) / 2)
-  #
+  OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
+    --model $MODEL \
+    --eval gpqa \
+    --reasoning-effort low \
+    --n-threads $(expr $(nproc) / 2)
+
   # Mid
   #OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
   #  --model $MODEL \

--- a/.github/scripts/gpt-oss/run_accuracy_checks.sh
+++ b/.github/scripts/gpt-oss/run_accuracy_checks.sh
@@ -63,7 +63,7 @@ if [[ "${DEVICE_NAME}" == "rocm" ]]; then
   # High
   OPENAI_API_KEY="" python3 -mevals --base-url http://localhost:8000/v1 \
     --model $MODEL \
-    --eval \
+    --eval aime25 \
     --reasoning-effort high \
     --n-threads $(expr $(nproc) / 2)
   popd

--- a/.github/scripts/gpt-oss/run_accuracy_checks.sh
+++ b/.github/scripts/gpt-oss/run_accuracy_checks.sh
@@ -30,22 +30,29 @@ fi
 pushd vllm-benchmarks/gpt-oss
 mkdir -p /tmp/gpqa_openai
 
+# Not sure why this is needed on ROCm image
+if [[ "${DEVICE_NAME}" == "rocm" ]]; then
+  ls -la gpt_oss
+  ls -la gpt_oss/evals
+  export PYTHONPATH=$(pwd):$PYTHONPATH
+fi
+
 # Low
-OPENAI_API_KEY='' python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
+OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
   --model $MODEL \
   --eval gpqa \
   --reasoning-effort low \
   --n-threads $(expr $(nproc) / 2)
 
 # Mid
-OPENAI_API_KEY='' python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
+OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
   --model $MODEL \
   --eval gpqa \
   --reasoning-effort medium \
   --n-threads $(expr $(nproc) / 2)
 
 # High
-OPENAI_API_KEY='' python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
+OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
   --model $MODEL \
   --eval gpqa \
   --reasoning-effort high \

--- a/.github/scripts/gpt-oss/run_accuracy_checks.sh
+++ b/.github/scripts/gpt-oss/run_accuracy_checks.sh
@@ -41,6 +41,7 @@ fi
 
 pushd vllm-benchmarks/gpt-oss
 mkdir -p /tmp/gpqa_openai
+mkdir -p /tmp/aime25_openai
 
 if [[ "${DEVICE_NAME}" == "rocm" ]]; then
   # Not sure why this is needed on ROCm
@@ -48,21 +49,21 @@ if [[ "${DEVICE_NAME}" == "rocm" ]]; then
   # Low
   OPENAI_API_KEY="" python3 -mevals --base-url http://localhost:8000/v1 \
     --model $MODEL \
-    --eval gpqa \
+    --eval aime25 \
     --reasoning-effort low \
     --n-threads $(expr $(nproc) / 2)
 
   # Mid
   OPENAI_API_KEY="" python3 -mevals --base-url http://localhost:8000/v1 \
     --model $MODEL \
-    --eval gpqa \
+    --eval aime25 \
     --reasoning-effort medium \
     --n-threads $(expr $(nproc) / 2)
 
   # High
   OPENAI_API_KEY="" python3 -mevals --base-url http://localhost:8000/v1 \
     --model $MODEL \
-    --eval gpqa \
+    --eval \
     --reasoning-effort high \
     --n-threads $(expr $(nproc) / 2)
   popd
@@ -70,26 +71,27 @@ else
   # Low
   OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
     --model $MODEL \
-    --eval gpqa \
+    --eval aime25 \
     --reasoning-effort low \
     --n-threads $(expr $(nproc) / 2)
 
   # Mid
   OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
     --model $MODEL \
-    --eval gpqa \
+    --eval aime25 \
     --reasoning-effort medium \
     --n-threads $(expr $(nproc) / 2)
 
   # High
   OPENAI_API_KEY="" python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
     --model $MODEL \
-    --eval gpqa \
+    --eval aime25 \
     --reasoning-effort high \
     --n-threads $(expr $(nproc) / 2)
 fi
 
 mv /tmp/gpqa_openai .
+mv /tmp/aime25_openai .
 popd
 
 kill -9 $server_pid

--- a/.github/scripts/gpt-oss/run_accuracy_checks.sh
+++ b/.github/scripts/gpt-oss/run_accuracy_checks.sh
@@ -2,6 +2,18 @@
 
 set -eux
 
+# https://docs.vllm.ai/projects/recipes/en/latest/OpenAI/GPT-OSS.html
+if [[ "${DEVICE_TYPE}" == *B200* ]]; then
+  export VLLM_USE_TRTLLM_ATTENTION=1
+  export VLLM_USE_TRTLLM_DECODE_ATTENTION=1
+  export VLLM_USE_TRTLLM_CONTEXT_ATTENTION=1
+  export VLLM_USE_FLASHINFER_MXFP4_BF16_MOE=1
+elif [[ "${DEVICE_NAME}" == *rocm* ]]; then
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_USE_AITER_UNIFIED_ATTENTION=1
+  export VLLM_ROCM_USE_AITER_MHA=0
+fi
+
 tp=0
 if [[ "${MODEL}" == "openai/gpt-oss-120b" ]]; then
   tp=4

--- a/.github/scripts/gpt-oss/run_benchmarks.sh
+++ b/.github/scripts/gpt-oss/run_benchmarks.sh
@@ -25,5 +25,6 @@ if [[ "${DEVICE_NAME}" != "rocm" ]]; then
 fi
 
 pip freeze
-bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
+# Just run accuracy tests for now
+# bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
 popd

--- a/.github/scripts/gpt-oss/run_benchmarks.sh
+++ b/.github/scripts/gpt-oss/run_benchmarks.sh
@@ -18,7 +18,7 @@ pushd vllm-benchmarks/vllm
 cp vllm/benchmarks/lib/utils.py /app/vllm-os-mini/vllm/benchmarks/utils.py || true
 
 if [[ "${DEVICE_NAME}" != "rocm" ]]; then
-  pip install -U openai transformers
+  pip install -U openai transformers setuptools
   pip install --pre vllm==0.10.1+gptoss \
     --extra-index-url https://wheels.vllm.ai/gpt-oss/ \
     --extra-index-url https://download.pytorch.org/whl/nightly/cu128

--- a/.github/scripts/gpt-oss/run_benchmarks.sh
+++ b/.github/scripts/gpt-oss/run_benchmarks.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -eux
+
+pushd vllm-benchmarks/vllm
+cp vllm/benchmarks/lib/utils.py /app/vllm-os-mini/vllm/benchmarks/utils.py || true
+
+if [[ $DEVICE_NAME != 'rocm' ]]; then
+  pip install -U openai transformers
+  pip install --pre vllm==0.10.1+gptoss \
+    --extra-index-url https://wheels.vllm.ai/gpt-oss/ \
+    --extra-index-url https://download.pytorch.org/whl/nightly/cu128
+fi
+
+pip freeze
+bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
+popd

--- a/.github/scripts/gpt-oss/run_benchmarks.sh
+++ b/.github/scripts/gpt-oss/run_benchmarks.sh
@@ -12,6 +12,8 @@ elif [[ "${DEVICE_NAME}" == *rocm* ]]; then
   export VLLM_ROCM_USE_AITER=1
   export VLLM_USE_AITER_UNIFIED_ATTENTION=1
   export VLLM_ROCM_USE_AITER_MHA=0
+else
+  export VLLM_FLASH_ATTN_VERSION=2
 fi
 
 pushd vllm-benchmarks/vllm
@@ -21,10 +23,6 @@ if [[ "${DEVICE_NAME}" != "rocm" ]]; then
   pip install -U openai transformers setuptools
   pip install --pre vllm==0.10.1+gptoss \
     --extra-index-url https://wheels.vllm.ai/gpt-oss/ \
-    --extra-index-url https://download.pytorch.org/whl/nightly/cu128
-
-  export TORCH_CUDA_ARCH_LIST='8.9 9.0'
-  pip install --no-build-isolation "git+https://github.com/facebookresearch/xformers@v0.0.31" \
     --extra-index-url https://download.pytorch.org/whl/nightly/cu128
 fi
 

--- a/.github/scripts/gpt-oss/run_benchmarks.sh
+++ b/.github/scripts/gpt-oss/run_benchmarks.sh
@@ -26,5 +26,5 @@ fi
 
 pip freeze
 # Just run accuracy tests for now
-# bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
+bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
 popd

--- a/.github/scripts/gpt-oss/run_benchmarks.sh
+++ b/.github/scripts/gpt-oss/run_benchmarks.sh
@@ -12,8 +12,6 @@ elif [[ "${DEVICE_NAME}" == *rocm* ]]; then
   export VLLM_ROCM_USE_AITER=1
   export VLLM_USE_AITER_UNIFIED_ATTENTION=1
   export VLLM_ROCM_USE_AITER_MHA=0
-else
-  export VLLM_FLASH_ATTN_VERSION=2
 fi
 
 pushd vllm-benchmarks/vllm

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -218,6 +218,9 @@ jobs:
           SANITIZED_DEVICE_TYPE=$(echo "${DEVICE_TYPE// /_}" | sed "s/[^[:alnum:].-]/_/g")
           SANITIZED_MODEL="${MODEL//\//_}"
 
+          echo "SANITIZED_DEVICE_TYPE=$SANITIZED_DEVICE_TYPE" >> $GITHUB_ENV
+          echo "SANITIZED_MODEL=$SANITIZED_MODEL" >> $GITHUB_ENV
+
           python3 .github/scripts/upload_benchmark_results.py \
             --repo vllm-benchmarks/vllm \
             --benchmark-name "vLLM benchmark" \
@@ -225,9 +228,6 @@ jobs:
             --device-name "${DEVICE_NAME}" \
             --device-type "${SANITIZED_DEVICE_TYPE}" \
             --model "${MODEL//\//_}"
-
-          echo "SANITIZED_DEVICE_TYPE=$SANITIZED_DEVICE_TYPE" >> $GITHUB_ENV
-          echo "SANITIZED_MODEL=$SANITIZED_MODEL" >> $GITHUB_ENV
 
       # Keep a copy of the benchmark results on GitHub for reference
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -1,0 +1,202 @@
+name: gpt-oss benchmark
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/gpt-oss-benchmark.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  cancel-in-progress: true
+
+jobs:
+  benchmarks:
+    name: Run gpt-oss benchmarks
+    needs: set-parameters
+    strategy:
+      matrix:
+        # gpt-oss-120b
+        # - runner: linux.aws.h100.4
+        #   model: openai/gpt-oss-120b
+        #   docker-image: 'vllm/vllm-openai:gptoss'
+        # - runner: linux.dgx.b200.8
+        #   model: openai/gpt-oss-120b
+        #   docker-image: 'vllm/vllm-openai:gptoss'
+        # - runner: linux.rocm.gpu.gfx942.4
+        #   model: openai/gpt-oss-120b
+        #   docker-image: rocm/vllm-dev:open-mi300-08052025
+        # gpt-oss-20b
+        - runner: linux.aws.h100
+          model: openai/gpt-oss-20b
+          docker-image: 'vllm/vllm-openai:gptoss'
+        - runner: linux.dgx.b200
+          model: openai/gpt-oss-20b
+          docker-image: 'vllm/vllm-openai:gptoss'
+        - runner: linux.rocm.gpu.gfx942.2
+          model: openai/gpt-oss-20b
+          docker-image: rocm/vllm-dev:open-mi300-08052025
+      fail-fast: false
+    runs-on: ${{ matrix.runner }}
+    environment: pytorch-x-vllm
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout vLLM repository
+        uses: actions/checkout@v4
+        with:
+          repository: vllm-project/vllm
+          path: vllm-benchmarks/vllm
+
+      - uses: actions/setup-python@v5
+        # Amazon Linux fails on this step
+        continue-on-error: true
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Check if the device is supported
+        shell: bash
+        run: |
+          set -eux
+
+          if command -v nvidia-smi; then
+            DEVICE_NAME=cuda
+            nvidia-smi
+          elif command -v rocm-smi; then
+            DEVICE_NAME=rocm
+            rocm-smi
+          else
+            DEVICE_NAME=cpu
+            lscpu
+          fi
+          echo "DEVICE_NAME=$DEVICE_NAME" >> $GITHUB_ENV
+
+      - name: Set GPU name and type
+        working-directory: vllm-benchmarks
+        shell: bash
+        run: |
+          set -eux
+
+          if [[ "${DEVICE_NAME}" == "cuda" ]]; then
+            DEVICE_TYPE=$(nvidia-smi -i 0 --query-gpu=name --format=csv,noheader | awk '{print $2}')
+          elif [[ "${DEVICE_NAME}" == "rocm" ]]; then
+            DEVICE_TYPE=$(rocminfo | grep "Marketing Name" | tail -n1 | awk -F':' '{print $2}' | xargs)
+          elif [[ "${DEVICE_NAME}" == "cpu" ]]; then
+            DEVICE_TYPE=$(lscpu | grep 'Model name' | cut -f 2 -d ":" | awk '{$1=$1}1' | cut -f 2 -d " ")
+          fi
+          echo "DEVICE_TYPE=$DEVICE_TYPE" >> $GITHUB_ENV
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -eux
+
+          if [[ "${DEVICE_NAME}" == "rocm" ]]; then
+            pip install -r .github/scripts/requirements.txt \
+              --extra-index-url https://download.pytorch.org/whl/rocm6.3
+          else
+            pip install -r .github/scripts/requirements.txt \
+              --extra-index-url https://download.pytorch.org/whl/cu128
+          fi
+
+      - name: Setup CUDA GPU_FLAG for docker run
+        if: env.DEVICE_NAME == 'cuda'
+        run: |
+          echo "GPU_FLAG=--gpus all -e NVIDIA_DRIVER_CAPABILITIES=all" >> "${GITHUB_ENV}"
+
+      - name: Setup ROCm
+        if: env.DEVICE_NAME == 'rocm'
+        uses: pytorch/pytorch/./.github/actions/setup-rocm@main
+
+      - name: Setup benchmark tests
+        env:
+          MODEL: ${{ matrix.model }}
+        run: |
+          set -eux
+
+          pushd vllm-benchmarks/vllm
+          git checkout "${HEAD_SHA}"
+          rm .buildkite/nightly-benchmarks/tests/*.json
+          popd
+
+          # Set the list of benchmarks we want to cover in this runner
+          python3 .github/scripts/setup_vllm_benchmark.py \
+            --from-benchmark-configs-dir vllm-benchmarks/benchmarks \
+            --to-benchmark-configs-dir vllm-benchmarks/vllm/.buildkite/nightly-benchmarks/tests \
+            --models "${MODEL}" \
+            --device "${DEVICE_NAME}"
+
+          pushd vllm-benchmarks/vllm
+          ls -lah .buildkite/nightly-benchmarks/tests
+          find .buildkite/nightly-benchmarks/tests -type f -exec cat {} \;
+          popd
+
+      - name: Run vLLM gpt-oss benchmark
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          DOCKER_IMAGE: ${{ matrix.docker-image }}
+          # vLLM-related environment variables
+          ENGINE_VERSION: v1
+          SAVE_TO_PYTORCH_BENCHMARK_FORMAT: 1
+        run: |
+          set -eux
+
+          container_name=$(docker run \
+            ${GPU_FLAG:-} \
+            -e DEVICE_NAME \
+            -e DEVICE_TYPE \
+            -e HF_TOKEN \
+            -e ENGINE_VERSION \
+            -e SAVE_TO_PYTORCH_BENCHMARK_FORMAT \
+            --ipc=host \
+            --tty \
+            --detach \
+            --security-opt seccomp=unconfined \
+            --shm-size=4g \
+            -v "${GITHUB_WORKSPACE}:/tmp/workspace" \
+            -w /tmp/workspace \
+            "${DOCKER_IMAGE}"
+          )
+          docker exec -t "${container_name}" bash -c "cd vllm-benchmarks/vllm && bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh"
+
+      - name: Authenticate with AWS
+        # AWS CUDA runners already have access to the bucket via its runner IAM role
+        if: env.DEVICE_NAME == 'rocm' || contains(env.DEVICE_TYPE, 'B200')
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_upload-benchmark-results
+          # The max duration enforced by the server side
+          role-duration-seconds: 18000
+          aws-region: us-east-1
+
+      - name: Upload the benchmark results
+        env:
+          BENCHMARK_RESULTS: vllm-benchmarks/vllm/benchmarks/results
+          MODEL: ${{ matrix.model }}
+        run: |
+          set -eux
+
+          sudo chown -R ${UID} "${BENCHMARK_RESULTS}"
+          ls -lah "${BENCHMARK_RESULTS}"
+
+          SANITIZED_DEVICE_TYPE=$(echo "${DEVICE_TYPE// /_}" | sed "s/[^[:alnum:].-]/_/g")
+          python3 .github/scripts/upload_benchmark_results.py \
+            --repo vllm-benchmarks/vllm \
+            --benchmark-name "vLLM benchmark" \
+            --benchmark-results "${BENCHMARK_RESULTS}" \
+            --device-name "${DEVICE_NAME}" \
+            --device-type "${SANITIZED_DEVICE_TYPE}" \
+            --model "${MODEL//\//_}"
+
+          echo "SANITIZED_DEVICE_TYPE=$SANITIZED_DEVICE_TYPE" >> $GITHUB_ENV
+          echo "SANITIZED_MODEL=$SANITIZED_MODEL" >> $GITHUB_ENV
+
+      # Keep a copy of the benchmark results on GitHub for reference
+      - uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results--${{ env.SANITIZED_DEVICE_TYPE }}-${{ env.SANITIZED_MODEL }}
+          path: vllm-benchmarks/vllm/benchmarks/results

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -213,6 +213,7 @@ jobs:
                 --extra-index-url https://wheels.vllm.ai/gpt-oss/ \
                 --extra-index-url https://download.pytorch.org/whl/nightly/cu128
             fi
+            sleep 7200
             bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
           "
 
@@ -237,6 +238,8 @@ jobs:
           ls -lah "${BENCHMARK_RESULTS}"
 
           SANITIZED_DEVICE_TYPE=$(echo "${DEVICE_TYPE// /_}" | sed "s/[^[:alnum:].-]/_/g")
+          SANITIZED_MODELS="${MODELS//\//_}"
+
           python3 .github/scripts/upload_benchmark_results.py \
             --repo vllm-benchmarks/vllm \
             --benchmark-name "vLLM benchmark" \

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -26,15 +26,16 @@ jobs:
         #   model: openai/gpt-oss-120b
         #   docker-image: rocm/vllm-dev:open-mi300-08052025
         # gpt-oss-20b
-        - runner: linux.aws.h100
-          model: openai/gpt-oss-20b
-          docker-image: 'vllm/vllm-openai:gptoss'
-        - runner: linux.dgx.b200
-          model: openai/gpt-oss-20b
-          docker-image: 'vllm/vllm-openai:gptoss'
-        - runner: linux.rocm.gpu.gfx942.2
-          model: openai/gpt-oss-20b
-          docker-image: rocm/vllm-dev:open-mi300-08052025
+        include:
+          - runner: linux.aws.h100
+            model: openai/gpt-oss-20b
+            docker-image: 'vllm/vllm-openai:gptoss'
+          - runner: linux.dgx.b200
+            model: openai/gpt-oss-20b
+            docker-image: 'vllm/vllm-openai:gptoss'
+          - runner: linux.rocm.gpu.gfx942.2
+            model: openai/gpt-oss-20b
+            docker-image: rocm/vllm-dev:open-mi300-08052025
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     environment: pytorch-x-vllm
@@ -50,6 +51,12 @@ jobs:
         with:
           repository: vllm-project/vllm
           path: vllm-benchmarks/vllm
+
+      - name: Checkout gpt-oss repository
+        uses: actions/checkout@v4
+        with:
+          repository: openai/gpt-oss
+          path: vllm-benchmarks/gpt-oss
 
       - uses: actions/setup-python@v5
         # Amazon Linux fails on this step

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -197,14 +197,10 @@ jobs:
             "${DOCKER_IMAGE}"
           )
           docker exec -t "${container_name}" bash -c "
-            set -x
             cd vllm-benchmarks/vllm
-            ls -la .
-            ls -la vllm
-            ls -la vllm/benchmarks
-
-            cp vllm/benchmarks/utils.py /app/vllm-os-mini/vllm/benchmarks/utils.py || true
+            cp vllm/benchmarks/lib/utils.py /app/vllm-os-mini/vllm/benchmarks/utils.py || true
             bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
+            sleep 7200
           "
 
       - name: Authenticate with AWS

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -199,8 +199,8 @@ jobs:
           docker exec -t "${container_name}" bash -c "
             cd vllm-benchmarks/vllm
             cp vllm/benchmarks/lib/utils.py /app/vllm-os-mini/vllm/benchmarks/utils.py || true
-            bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh || true
             sleep 7200
+            bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh || true
           "
 
       - name: Authenticate with AWS

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           # gpt-oss-120b
-          - runner: linux.aws.h100.4
+          - runner: linux.aws.h100.8
             model: openai/gpt-oss-120b
             docker-image: 'public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:6d8d0a24c02bfd84d46b3016b865a44f048ae84b'
           - runner: linux.dgx.b200.8

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -191,7 +191,7 @@ jobs:
           # Run perf tests
           docker exec -t "${container_name}" bash .github/scripts/gpt-oss/run_benchmarks.sh
 
-          # Run accuracy check
+          # Run accuracy check (turning this on later if needed)
           # docker exec -t "${container_name}" bash .github/scripts/gpt-oss/run_accuracy_checks.sh
 
       - name: Authenticate with AWS

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -26,7 +26,7 @@ jobs:
             model: openai/gpt-oss-120b
             docker-image: rocm/vllm-dev:open-mi300-08052025
           # gpt-oss-20b
-          - runner: linux.aws.h100
+          - runner: linux.aws.h100.4
             model: openai/gpt-oss-20b
             docker-image: 'vllm/vllm-openai:gptoss'
           - runner: linux.dgx.b200
@@ -199,7 +199,7 @@ jobs:
           docker exec -t "${container_name}" bash -c "
             cd vllm-benchmarks/vllm
             cp vllm/benchmarks/lib/utils.py /app/vllm-os-mini/vllm/benchmarks/utils.py || true
-            bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
+            bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh || true
             sleep 7200
           "
 

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -125,7 +125,6 @@ jobs:
           set -eux
 
           pushd vllm-benchmarks/vllm
-          git checkout "${HEAD_SHA}"
           rm .buildkite/nightly-benchmarks/tests/*.json
           popd
 
@@ -181,6 +180,13 @@ jobs:
             -e HF_TOKEN \
             -e ENGINE_VERSION \
             -e SAVE_TO_PYTORCH_BENCHMARK_FORMAT \
+            -e VLLM_USE_TRTLLM_ATTENTION \
+            -e VLLM_USE_TRTLLM_DECODE_ATTENTION \
+            -e VLLM_USE_TRTLLM_CONTEXT_ATTENTION \
+            -e VLLM_USE_FLASHINFER_MXFP4_BF16_MOE \
+            -e VLLM_ROCM_USE_AITER \
+            -e VLLM_USE_AITER_UNIFIED_ATTENTION \
+            -e VLLM_ROCM_USE_AITER_MHA \
             --ipc=host \
             --tty \
             --detach \

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -192,7 +192,7 @@ jobs:
           docker exec -t "${container_name}" bash .github/scripts/gpt-oss/run_benchmarks.sh
 
           # Run accuracy check (turning this on later if needed)
-          # docker exec -t "${container_name}" bash .github/scripts/gpt-oss/run_accuracy_checks.sh
+          docker exec -t "${container_name}" bash .github/scripts/gpt-oss/run_accuracy_checks.sh
 
       - name: Authenticate with AWS
         # AWS CUDA runners already have access to the bucket via its runner IAM role

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -22,7 +22,7 @@ jobs:
           - runner: linux.dgx.b200.8
             model: openai/gpt-oss-120b
             docker-image: 'public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:6d8d0a24c02bfd84d46b3016b865a44f048ae84b'
-          - runner: linux.rocm.gpu.gfx942.4
+          - runner: linux.rocm.gpu.gfx942.8
             model: openai/gpt-oss-120b
             docker-image: rocm/vllm-dev:open-mi300-08052025
           # gpt-oss-20b

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -209,11 +209,11 @@ jobs:
             "${DOCKER_IMAGE}"
           )
 
-          # Run accuracy check
-          docker exec -t "${container_name}" bash .github/scripts/gpt-oss/run_accuracy_checks.sh
-
           # Run perf tests
           docker exec -t "${container_name}" bash .github/scripts/gpt-oss/run_benchmarks.sh
+
+          # Run accuracy check
+          docker exec -t "${container_name}" bash .github/scripts/gpt-oss/run_accuracy_checks.sh
 
       - name: Authenticate with AWS
         # AWS CUDA runners already have access to the bucket via its runner IAM role

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -205,6 +205,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Upload the benchmark results
+        continue-on-error: true
         env:
           BENCHMARK_RESULTS: vllm-benchmarks/vllm/benchmarks/results
           MODEL: ${{ matrix.model }}

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -210,80 +210,10 @@ jobs:
           )
 
           # Run accuracy check
-          docker exec -t "${container_name}" bash -c "
-            set -eux
-
-            echo $MODEL
-
-            tp=0
-            if [[ $MODEL == 'openai/gpt-oss-120b' ]]; then
-              tp=4
-            elif [[ $MODEL == 'openai/gpt-oss-20b' ]]; then
-              tp=1
-            fi
-
-            echo $tp
-            # Prepare the accuracy test
-            vllm serve $MODEL --tensor_parallel_size $tp &
-            server_pid=$!
-
-            wait_for_server() {
-              timeout 1200 bash -c '
-                until curl -X POST localhost:8000/v1/completions; do
-                  sleep 1
-                done' && return 0 || return 1
-            }
-
-            if wait_for_server; then
-              echo 'vLLM server is up and running'
-            else
-              echo 'vLLM failed to start within the timeout period'
-            fi
-
-            pushd vllm-benchmarks/gpt-oss
-            mkdir -p /tmp/gpqa_openai
-
-            # Low
-            OPENAI_API_KEY='' python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
-              --model $MODEL \
-              --eval gpqa \
-              --reasoning-effort low \
-              --n-threads $(expr $(nproc) / 2)
-
-            # Mid
-            OPENAI_API_KEY='' python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
-              --model $MODEL \
-              --eval gpqa \
-              --reasoning-effort medium \
-              --n-threads $(expr $(nproc) / 2)
-
-            # High
-            OPENAI_API_KEY='' python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
-              --model $MODEL \
-              --eval gpqa \
-              --reasoning-effort high \
-              --n-threads $(expr $(nproc) / 2)
-
-            mv /tmp/gpqa_openai .
-            popd
-
-            kill -9 $server_pid
-          "
+          docker exec -t "${container_name}" bash .github/scripts/gpt-oss/run_accuracy_checks.sh
 
           # Run perf tests
-          docker exec -t "${container_name}" bash -c "
-            pushd vllm-benchmarks/vllm
-            cp vllm/benchmarks/lib/utils.py /app/vllm-os-mini/vllm/benchmarks/utils.py || true
-            if [[ $DEVICE_NAME != 'rocm' ]]; then
-              pip install -U openai transformers
-              pip install --pre vllm==0.10.1+gptoss \
-                --extra-index-url https://wheels.vllm.ai/gpt-oss/ \
-                --extra-index-url https://download.pytorch.org/whl/nightly/cu128
-            fi
-            pip freeze
-            bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
-            popd
-          "
+          docker exec -t "${container_name}" bash .github/scripts/gpt-oss/run_benchmarks.sh
 
       - name: Authenticate with AWS
         # AWS CUDA runners already have access to the bucket via its runner IAM role

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -26,13 +26,13 @@ jobs:
             model: openai/gpt-oss-120b
             docker-image: rocm/vllm-dev:open-mi300-08052025
           # gpt-oss-20b
-          - runner: linux.aws.h100
+          - runner: linux.aws.h100.4
             model: openai/gpt-oss-20b
             docker-image: 'public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:6d8d0a24c02bfd84d46b3016b865a44f048ae84b'
-          - runner: linux.dgx.b200
+          - runner: linux.dgx.b200.8
             model: openai/gpt-oss-20b
             docker-image: 'public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:6d8d0a24c02bfd84d46b3016b865a44f048ae84b'
-          - runner: linux.rocm.gpu.gfx942.2
+          - runner: linux.rocm.gpu.gfx942.8
             model: openai/gpt-oss-20b
             docker-image: rocm/vllm-dev:open-mi300-08052025
       fail-fast: false

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -26,7 +26,7 @@ jobs:
             model: openai/gpt-oss-120b
             docker-image: rocm/vllm-dev:open-mi300-08052025
           # gpt-oss-20b
-          - runner: linux.aws.h100.4
+          - runner: linux.aws.h100
             model: openai/gpt-oss-20b
             docker-image: 'public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:6d8d0a24c02bfd84d46b3016b865a44f048ae84b'
           - runner: linux.dgx.b200
@@ -150,10 +150,12 @@ jobs:
           # vLLM-related environment variables
           ENGINE_VERSION: v1
           SAVE_TO_PYTORCH_BENCHMARK_FORMAT: 1
+          MODEL: ${{ matrix.model }}
         run: |
           set -eux
 
           if [[ "${DEVICE_TYPE}" == *B200* ]]; then
+            # Just to unblock this change on B200
             aws configure set aws_access_key_id "${AWS_ACCESS_KEY_ID}"
             aws configure set aws_secret_access_key "${AWS_SECRET_ACCESS_KEY}"
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
@@ -184,6 +186,7 @@ jobs:
 
           container_name=$(docker run \
             ${GPU_FLAG:-} \
+            -e MODEL \
             -e DEVICE_NAME \
             -e DEVICE_TYPE \
             -e HF_TOKEN \
@@ -205,16 +208,76 @@ jobs:
             -w /tmp/workspace \
             "${DOCKER_IMAGE}"
           )
+
+          # Run perf tests
           docker exec -t "${container_name}" bash -c "
-            cd vllm-benchmarks/vllm
+            pushd vllm-benchmarks/vllm
             cp vllm/benchmarks/lib/utils.py /app/vllm-os-mini/vllm/benchmarks/utils.py || true
             if [[ $DEVICE_NAME != 'rocm' ]]; then
+              pip install -U openai transformers
               pip install --pre vllm==0.10.1+gptoss \
                 --extra-index-url https://wheels.vllm.ai/gpt-oss/ \
                 --extra-index-url https://download.pytorch.org/whl/nightly/cu128
             fi
-            sleep 7200
+            pip freeze
             bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
+            popd
+          "
+
+          # Run accuracy check
+          docker exec -t "${container_name}" bash -c "
+            local tp
+            if [[ $MODEL == 'openai/gpt-oss-120b' ]]; then
+              tp=4
+            elfi [[ $MODEL == 'openai/gpt-oss-20b' ]]; then
+              tp=1
+            fi
+
+            # Prepare the accuracy test
+            vllm serve $MODEL --tensor_parallel_size $tp &
+            server_pid=$!
+
+            wait_for_server() {
+              timeout 1200 bash -c '
+                until curl -X POST localhost:8000/v1/completions; do
+                  sleep 1
+                done' && return 0 || return 1
+            }
+
+            if wait_for_server; then
+              echo 'vLLM server is up and running'
+            else
+              echo 'vLLM failed to start within the timeout period'
+            fi
+
+            pushd vllm-benchmarks/gpt-oss
+            mkdir -p /tmp/gpqa_openai
+
+            # Low
+            OPENAI_API_KEY='' python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
+              --model $MODEL \
+              --eval gpqa \
+              --reasoning-effort low \
+              --n-threads $(expr $(nproc) / 2)
+
+            # Mid
+            OPENAI_API_KEY='' python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
+              --model $MODEL \
+              --eval gpqa \
+              --reasoning-effort medium \
+              --n-threads $(expr $(nproc) / 2)
+
+            # High
+            OPENAI_API_KEY='' python3 -m gpt_oss.evals --base-url http://localhost:8000/v1 \
+              --model $MODEL \
+              --eval gpqa \
+              --reasoning-effort high \
+              --n-threads $(expr $(nproc) / 2)
+
+            mv /tmp/gpqa_openai .
+            popd
+
+            kill -9 $server_pid
           "
 
       - name: Authenticate with AWS
@@ -256,3 +319,10 @@ jobs:
         with:
           name: benchmark-results--${{ env.SANITIZED_DEVICE_TYPE }}-${{ env.SANITIZED_MODEL }}
           path: vllm-benchmarks/vllm/benchmarks/results
+
+      # Keep a copy of the accuracy results on GitHub for reference
+      - uses: actions/upload-artifact@v4
+        with:
+          name: accuracy-results--${{ env.SANITIZED_DEVICE_TYPE }}-${{ env.SANITIZED_MODEL }}
+          path: |
+            vllm-benchmarks/gpt-oss/gpqa_openai

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -41,6 +41,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    timeout-minutes: 720
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -138,7 +139,7 @@ jobs:
           pushd vllm-benchmarks/vllm
           ls -lah .buildkite/nightly-benchmarks/tests
           find .buildkite/nightly-benchmarks/tests -type f -exec cat {} \;
-          popd
+
 
       - name: Run vLLM gpt-oss benchmark
         env:
@@ -206,7 +207,7 @@ jobs:
           ls -lah "${BENCHMARK_RESULTS}"
 
           SANITIZED_DEVICE_TYPE=$(echo "${DEVICE_TYPE// /_}" | sed "s/[^[:alnum:].-]/_/g")
-          SANITIZED_MODELS="${MODELS//\//_}"
+          SANITIZED_MODEL="${MODEL//\//_}"
 
           python3 .github/scripts/upload_benchmark_results.py \
             --repo vllm-benchmarks/vllm \

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -192,7 +192,7 @@ jobs:
           docker exec -t "${container_name}" bash .github/scripts/gpt-oss/run_benchmarks.sh
 
           # Run accuracy check
-          docker exec -t "${container_name}" bash .github/scripts/gpt-oss/run_accuracy_checks.sh
+          # docker exec -t "${container_name}" bash .github/scripts/gpt-oss/run_accuracy_checks.sh
 
       - name: Authenticate with AWS
         # AWS CUDA runners already have access to the bucket via its runner IAM role

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -14,18 +14,18 @@ jobs:
     name: Run gpt-oss benchmarks
     strategy:
       matrix:
-        # gpt-oss-120b
-        - runner: linux.aws.h100.4
-          model: openai/gpt-oss-120b
-          docker-image: 'vllm/vllm-openai:gptoss'
-        - runner: linux.dgx.b200.8
-          model: openai/gpt-oss-120b
-          docker-image: 'vllm/vllm-openai:gptoss'
-        - runner: linux.rocm.gpu.gfx942.4
-          model: openai/gpt-oss-120b
-          docker-image: rocm/vllm-dev:open-mi300-08052025
-        # gpt-oss-20b
         include:
+          # gpt-oss-120b
+          - runner: linux.aws.h100.4
+            model: openai/gpt-oss-120b
+            docker-image: 'vllm/vllm-openai:gptoss'
+          - runner: linux.dgx.b200.8
+            model: openai/gpt-oss-120b
+            docker-image: 'vllm/vllm-openai:gptoss'
+          - runner: linux.rocm.gpu.gfx942.4
+            model: openai/gpt-oss-120b
+            docker-image: rocm/vllm-dev:open-mi300-08052025
+          # gpt-oss-20b
           - runner: linux.aws.h100
             model: openai/gpt-oss-20b
             docker-image: 'vllm/vllm-openai:gptoss'

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -226,7 +226,7 @@ jobs:
 
           # Run accuracy check
           docker exec -t "${container_name}" bash -c "
-            local tp=0
+            tp=0
             if [[ $MODEL == 'openai/gpt-oss-120b' ]]; then
               tp=4
             elif [[ $MODEL == 'openai/gpt-oss-20b' ]]; then

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -226,10 +226,10 @@ jobs:
 
           # Run accuracy check
           docker exec -t "${container_name}" bash -c "
-            local tp
+            local tp=0
             if [[ $MODEL == 'openai/gpt-oss-120b' ]]; then
               tp=4
-            elfi [[ $MODEL == 'openai/gpt-oss-20b' ]]; then
+            elif [[ $MODEL == 'openai/gpt-oss-20b' ]]; then
               tp=1
             fi
 

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -209,23 +209,12 @@ jobs:
             "${DOCKER_IMAGE}"
           )
 
-          # Run perf tests
-          docker exec -t "${container_name}" bash -c "
-            pushd vllm-benchmarks/vllm
-            cp vllm/benchmarks/lib/utils.py /app/vllm-os-mini/vllm/benchmarks/utils.py || true
-            if [[ $DEVICE_NAME != 'rocm' ]]; then
-              pip install -U openai transformers
-              pip install --pre vllm==0.10.1+gptoss \
-                --extra-index-url https://wheels.vllm.ai/gpt-oss/ \
-                --extra-index-url https://download.pytorch.org/whl/nightly/cu128
-            fi
-            pip freeze
-            bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
-            popd
-          "
-
           # Run accuracy check
           docker exec -t "${container_name}" bash -c "
+            set -eux
+
+            echo $MODEL
+
             tp=0
             if [[ $MODEL == 'openai/gpt-oss-120b' ]]; then
               tp=4
@@ -233,6 +222,7 @@ jobs:
               tp=1
             fi
 
+            echo $tp
             # Prepare the accuracy test
             vllm serve $MODEL --tensor_parallel_size $tp &
             server_pid=$!
@@ -278,6 +268,21 @@ jobs:
             popd
 
             kill -9 $server_pid
+          "
+
+          # Run perf tests
+          docker exec -t "${container_name}" bash -c "
+            pushd vllm-benchmarks/vllm
+            cp vllm/benchmarks/lib/utils.py /app/vllm-os-mini/vllm/benchmarks/utils.py || true
+            if [[ $DEVICE_NAME != 'rocm' ]]; then
+              pip install -U openai transformers
+              pip install --pre vllm==0.10.1+gptoss \
+                --extra-index-url https://wheels.vllm.ai/gpt-oss/ \
+                --extra-index-url https://download.pytorch.org/whl/nightly/cu128
+            fi
+            pip freeze
+            bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
+            popd
           "
 
       - name: Authenticate with AWS

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -161,29 +161,6 @@ jobs:
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
           fi
 
-          # https://docs.vllm.ai/projects/recipes/en/latest/OpenAI/GPT-OSS.html
-          if [[ "${DEVICE_TYPE}" == *B200* ]]; then
-            export VLLM_USE_TRTLLM_ATTENTION=1
-            export VLLM_USE_TRTLLM_DECODE_ATTENTION=1
-            export VLLM_USE_TRTLLM_CONTEXT_ATTENTION=1
-            export VLLM_USE_FLASHINFER_MXFP4_BF16_MOE=1
-          else
-            export VLLM_USE_TRTLLM_ATTENTION=0
-            export VLLM_USE_TRTLLM_DECODE_ATTENTION=0
-            export VLLM_USE_TRTLLM_CONTEXT_ATTENTION=0
-            export VLLM_USE_FLASHINFER_MXFP4_BF16_MOE=0
-          fi
-
-          if [[ "${DEVICE_NAME}" == *rocm* ]]; then
-            export VLLM_ROCM_USE_AITER=1
-            export VLLM_USE_AITER_UNIFIED_ATTENTION=1
-            export VLLM_ROCM_USE_AITER_MHA=0
-          else
-            export VLLM_ROCM_USE_AITER=0
-            export VLLM_USE_AITER_UNIFIED_ATTENTION=0
-            export VLLM_ROCM_USE_AITER_MHA=0
-          fi
-
           container_name=$(docker run \
             ${GPU_FLAG:-} \
             -e MODEL \
@@ -192,13 +169,6 @@ jobs:
             -e HF_TOKEN \
             -e ENGINE_VERSION \
             -e SAVE_TO_PYTORCH_BENCHMARK_FORMAT \
-            -e VLLM_USE_TRTLLM_ATTENTION \
-            -e VLLM_USE_TRTLLM_DECODE_ATTENTION \
-            -e VLLM_USE_TRTLLM_CONTEXT_ATTENTION \
-            -e VLLM_USE_FLASHINFER_MXFP4_BF16_MOE \
-            -e VLLM_ROCM_USE_AITER \
-            -e VLLM_USE_AITER_UNIFIED_ATTENTION \
-            -e VLLM_ROCM_USE_AITER_MHA \
             --ipc=host \
             --tty \
             --detach \

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -142,6 +142,9 @@ jobs:
 
       - name: Run vLLM gpt-oss benchmark
         env:
+          # To login to public.ecr.aws
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           DOCKER_IMAGE: ${{ matrix.docker-image }}
           # vLLM-related environment variables
@@ -149,6 +152,12 @@ jobs:
           SAVE_TO_PYTORCH_BENCHMARK_FORMAT: 1
         run: |
           set -eux
+
+          if [[ "${DEVICE_TYPE}" == *B200* ]]; then
+            aws configure set aws_access_key_id "${AWS_ACCESS_KEY_ID}"
+            aws configure set aws_secret_access_key "${AWS_SECRET_ACCESS_KEY}"
+            aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+          fi
 
           # https://docs.vllm.ai/projects/recipes/en/latest/OpenAI/GPT-OSS.html
           if [[ "${DEVICE_TYPE}" == *B200* ]]; then
@@ -199,13 +208,11 @@ jobs:
           docker exec -t "${container_name}" bash -c "
             cd vllm-benchmarks/vllm
             cp vllm/benchmarks/lib/utils.py /app/vllm-os-mini/vllm/benchmarks/utils.py || true
-
-            pip install --pre vllm==0.10.1+gptoss \
-              --extra-index-url https://wheels.vllm.ai/gpt-oss/ \
-              --extra-index-url https://download.pytorch.org/whl/nightly/cu128 \
-              --index-strategy unsafe-best-match
-            sleep 7200
-
+            if [[ $DEVICE_NAME != 'rocm' ]]; then
+              pip install --pre vllm==0.10.1+gptoss \
+                --extra-index-url https://wheels.vllm.ai/gpt-oss/ \
+                --extra-index-url https://download.pytorch.org/whl/nightly/cu128
+            fi
             bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
           "
 

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -162,6 +162,12 @@ jobs:
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
           fi
 
+          # Leaving 1GB for the runner and other things
+          TOTAL_AVAILABLE_MEMORY_IN_GB=$(awk '/MemTotal/ { printf "%.3f \n", $2/1024/1024 - 1 }' /proc/meminfo)
+          # https://docs.docker.com/engine/containers/resource_constraints/#--memory-swap-details, the 3GB swap
+          # comes from https://github.com/pytorch/test-infra/pull/6058
+          TOTAL_MEMORY_WITH_SWAP=$(("${TOTAL_AVAILABLE_MEMORY_IN_GB%.*}" + 3))
+
           container_name=$(docker run \
             ${GPU_FLAG:-} \
             -e MODEL \
@@ -170,6 +176,8 @@ jobs:
             -e HF_TOKEN \
             -e ENGINE_VERSION \
             -e SAVE_TO_PYTORCH_BENCHMARK_FORMAT \
+            --memory="${TOTAL_AVAILABLE_MEMORY_IN_GB%.*}g" \
+            --memory-swap="${TOTAL_MEMORY_WITH_SWAP}g" \
             --ipc=host \
             --tty \
             --detach \

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -18,20 +18,20 @@ jobs:
           # gpt-oss-120b
           - runner: linux.aws.h100.4
             model: openai/gpt-oss-120b
-            docker-image: 'vllm/vllm-openai:gptoss'
+            docker-image: 'public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:6d8d0a24c02bfd84d46b3016b865a44f048ae84b'
           - runner: linux.dgx.b200.8
             model: openai/gpt-oss-120b
-            docker-image: 'vllm/vllm-openai:gptoss'
+            docker-image: 'public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:6d8d0a24c02bfd84d46b3016b865a44f048ae84b'
           - runner: linux.rocm.gpu.gfx942.4
             model: openai/gpt-oss-120b
             docker-image: rocm/vllm-dev:open-mi300-08052025
           # gpt-oss-20b
           - runner: linux.aws.h100.4
             model: openai/gpt-oss-20b
-            docker-image: 'vllm/vllm-openai:gptoss'
+            docker-image: 'public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:6d8d0a24c02bfd84d46b3016b865a44f048ae84b'
           - runner: linux.dgx.b200
             model: openai/gpt-oss-20b
-            docker-image: 'vllm/vllm-openai:gptoss'
+            docker-image: 'public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:6d8d0a24c02bfd84d46b3016b865a44f048ae84b'
           - runner: linux.rocm.gpu.gfx942.2
             model: openai/gpt-oss-20b
             docker-image: rocm/vllm-dev:open-mi300-08052025
@@ -199,8 +199,14 @@ jobs:
           docker exec -t "${container_name}" bash -c "
             cd vllm-benchmarks/vllm
             cp vllm/benchmarks/lib/utils.py /app/vllm-os-mini/vllm/benchmarks/utils.py || true
+
+            pip install --pre vllm==0.10.1+gptoss \
+              --extra-index-url https://wheels.vllm.ai/gpt-oss/ \
+              --extra-index-url https://download.pytorch.org/whl/nightly/cu128 \
+              --index-strategy unsafe-best-match
             sleep 7200
-            bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh || true
+
+            bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
           "
 
       - name: Authenticate with AWS

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -15,15 +15,15 @@ jobs:
     strategy:
       matrix:
         # gpt-oss-120b
-        # - runner: linux.aws.h100.4
-        #   model: openai/gpt-oss-120b
-        #   docker-image: 'vllm/vllm-openai:gptoss'
-        # - runner: linux.dgx.b200.8
-        #   model: openai/gpt-oss-120b
-        #   docker-image: 'vllm/vllm-openai:gptoss'
-        # - runner: linux.rocm.gpu.gfx942.4
-        #   model: openai/gpt-oss-120b
-        #   docker-image: rocm/vllm-dev:open-mi300-08052025
+        - runner: linux.aws.h100.4
+          model: openai/gpt-oss-120b
+          docker-image: 'vllm/vllm-openai:gptoss'
+        - runner: linux.dgx.b200.8
+          model: openai/gpt-oss-120b
+          docker-image: 'vllm/vllm-openai:gptoss'
+        - runner: linux.rocm.gpu.gfx942.4
+          model: openai/gpt-oss-120b
+          docker-image: rocm/vllm-dev:open-mi300-08052025
         # gpt-oss-20b
         include:
           - runner: linux.aws.h100
@@ -199,6 +199,10 @@ jobs:
           docker exec -t "${container_name}" bash -c "
             set -x
             cd vllm-benchmarks/vllm
+            ls -la .
+            ls -la vllm
+            ls -la vllm/benchmarks
+
             cp vllm/benchmarks/utils.py /app/vllm-os-mini/vllm/benchmarks/utils.py || true
             bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
           "

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -241,3 +241,4 @@ jobs:
           name: accuracy-results--${{ env.SANITIZED_DEVICE_TYPE }}-${{ env.SANITIZED_MODEL }}
           path: |
             vllm-benchmarks/gpt-oss/gpqa_openai
+            vllm-benchmarks/gpt-oss/aime25_openai

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -12,7 +12,6 @@ concurrency:
 jobs:
   benchmarks:
     name: Run gpt-oss benchmarks
-    needs: set-parameters
     strategy:
       matrix:
         # gpt-oss-120b
@@ -151,6 +150,29 @@ jobs:
           SAVE_TO_PYTORCH_BENCHMARK_FORMAT: 1
         run: |
           set -eux
+
+          # https://docs.vllm.ai/projects/recipes/en/latest/OpenAI/GPT-OSS.html
+          if [[ "${DEVICE_TYPE}" == *B200* ]]; then
+            export VLLM_USE_TRTLLM_ATTENTION=1
+            export VLLM_USE_TRTLLM_DECODE_ATTENTION=1
+            export VLLM_USE_TRTLLM_CONTEXT_ATTENTION=1
+            export VLLM_USE_FLASHINFER_MXFP4_BF16_MOE=1
+          else
+            export VLLM_USE_TRTLLM_ATTENTION=
+            export VLLM_USE_TRTLLM_DECODE_ATTENTION=
+            export VLLM_USE_TRTLLM_CONTEXT_ATTENTION=
+            export VLLM_USE_FLASHINFER_MXFP4_BF16_MOE=
+          fi
+
+          if [[ "${DEVICE_NAME}" == *rocm* ]]; then
+            export VLLM_ROCM_USE_AITER=1
+            export VLLM_USE_AITER_UNIFIED_ATTENTION=1
+            export VLLM_ROCM_USE_AITER_MHA=0
+          else
+            export VLLM_ROCM_USE_AITER=
+            export VLLM_USE_AITER_UNIFIED_ATTENTION=
+            export VLLM_ROCM_USE_AITER_MHA=
+          fi
 
           container_name=$(docker run \
             ${GPU_FLAG:-} \

--- a/.github/workflows/gpt-oss-benchmark.yml
+++ b/.github/workflows/gpt-oss-benchmark.yml
@@ -157,10 +157,10 @@ jobs:
             export VLLM_USE_TRTLLM_CONTEXT_ATTENTION=1
             export VLLM_USE_FLASHINFER_MXFP4_BF16_MOE=1
           else
-            export VLLM_USE_TRTLLM_ATTENTION=
-            export VLLM_USE_TRTLLM_DECODE_ATTENTION=
-            export VLLM_USE_TRTLLM_CONTEXT_ATTENTION=
-            export VLLM_USE_FLASHINFER_MXFP4_BF16_MOE=
+            export VLLM_USE_TRTLLM_ATTENTION=0
+            export VLLM_USE_TRTLLM_DECODE_ATTENTION=0
+            export VLLM_USE_TRTLLM_CONTEXT_ATTENTION=0
+            export VLLM_USE_FLASHINFER_MXFP4_BF16_MOE=0
           fi
 
           if [[ "${DEVICE_NAME}" == *rocm* ]]; then
@@ -168,9 +168,9 @@ jobs:
             export VLLM_USE_AITER_UNIFIED_ATTENTION=1
             export VLLM_ROCM_USE_AITER_MHA=0
           else
-            export VLLM_ROCM_USE_AITER=
-            export VLLM_USE_AITER_UNIFIED_ATTENTION=
-            export VLLM_ROCM_USE_AITER_MHA=
+            export VLLM_ROCM_USE_AITER=0
+            export VLLM_USE_AITER_UNIFIED_ATTENTION=0
+            export VLLM_ROCM_USE_AITER_MHA=0
           fi
 
           container_name=$(docker run \
@@ -196,7 +196,12 @@ jobs:
             -w /tmp/workspace \
             "${DOCKER_IMAGE}"
           )
-          docker exec -t "${container_name}" bash -c "cd vllm-benchmarks/vllm && bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh"
+          docker exec -t "${container_name}" bash -c "
+            set -x
+            cd vllm-benchmarks/vllm
+            cp vllm/benchmarks/utils.py /app/vllm-os-mini/vllm/benchmarks/utils.py || true
+            bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
+          "
 
       - name: Authenticate with AWS
         # AWS CUDA runners already have access to the bucket via its runner IAM role

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -26,10 +26,6 @@ on:
         required: true
         type: string
         default: h100,mi300,spr
-  pull_request:
-    paths:
-      - .github/workflows/vllm-benchmark.yml
-      - vllm-benchmarks/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}

--- a/vllm-benchmarks/benchmarks/cuda/latency-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/latency-tests.json
@@ -59,8 +59,7 @@
             "load_format": "dummy",
             "num_iters_warmup": 5,
             "num_iters": 15,
-            "max_model_len": 8192,
-            "gpu_memory_utilization": 0.95
+            "max_model_len": 4096
         }
     },
     {
@@ -71,7 +70,7 @@
             "load_format": "dummy",
             "num_iters_warmup": 5,
             "num_iters": 15,
-            "max_model_len": 8192
+            "max_model_len": 4096
         }
     },
     {
@@ -82,7 +81,7 @@
             "load_format": "dummy",
             "num_iters_warmup": 5,
             "num_iters": 15,
-            "max_model_len": 8192
+            "max_model_len": 4096
         }
     }
 ]

--- a/vllm-benchmarks/benchmarks/cuda/latency-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/latency-tests.json
@@ -50,5 +50,38 @@
             "num_iters": 15,
             "max_model_len": 8192
         }
+    },
+    {
+        "test_name": "latency_gpt_oss_20b_tp1",
+        "parameters": {
+            "model": "openai/gpt-oss-20b",
+            "tensor_parallel_size": 1,
+            "load_format": "dummy",
+            "num_iters_warmup": 5,
+            "num_iters": 15,
+            "max_model_len": 8192
+        }
+    },
+    {
+        "test_name": "latency_gpt_oss_120b_tp2",
+        "parameters": {
+            "model": "openai/gpt-oss-120b",
+            "tensor_parallel_size": 2,
+            "load_format": "dummy",
+            "num_iters_warmup": 5,
+            "num_iters": 15,
+            "max_model_len": 8192
+        }
+    },
+    {
+        "test_name": "latency_gpt_oss_120b_tp4",
+        "parameters": {
+            "model": "openai/gpt-oss-120b",
+            "tensor_parallel_size": 4,
+            "load_format": "dummy",
+            "num_iters_warmup": 5,
+            "num_iters": 15,
+            "max_model_len": 8192
+        }
     }
 ]

--- a/vllm-benchmarks/benchmarks/cuda/latency-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/latency-tests.json
@@ -59,8 +59,7 @@
             "load_format": "dummy",
             "num_iters_warmup": 5,
             "num_iters": 15,
-            "max_model_len": 4096,
-            "gpu_memory_utilization": 0.95
+            "max_model_len": 4096
         }
     },
     {

--- a/vllm-benchmarks/benchmarks/cuda/latency-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/latency-tests.json
@@ -59,7 +59,8 @@
             "load_format": "dummy",
             "num_iters_warmup": 5,
             "num_iters": 15,
-            "max_model_len": 4096
+            "max_model_len": 4096,
+            "gpu_memory_utilization": 0.95
         }
     },
     {

--- a/vllm-benchmarks/benchmarks/cuda/latency-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/latency-tests.json
@@ -59,7 +59,7 @@
             "load_format": "dummy",
             "num_iters_warmup": 5,
             "num_iters": 15,
-            "max_model_len": 4096
+            "max_model_len": 8192
         }
     },
     {
@@ -70,7 +70,7 @@
             "load_format": "dummy",
             "num_iters_warmup": 5,
             "num_iters": 15,
-            "max_model_len": 4096
+            "max_model_len": 8192
         }
     },
     {
@@ -81,7 +81,7 @@
             "load_format": "dummy",
             "num_iters_warmup": 5,
             "num_iters": 15,
-            "max_model_len": 4096
+            "max_model_len": 8192
         }
     }
 ]

--- a/vllm-benchmarks/benchmarks/cuda/latency-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/latency-tests.json
@@ -59,7 +59,8 @@
             "load_format": "dummy",
             "num_iters_warmup": 5,
             "num_iters": 15,
-            "max_model_len": 8192
+            "max_model_len": 8192,
+            "gpu_memory_utilization": 0.95
         }
     },
     {

--- a/vllm-benchmarks/benchmarks/cuda/serving-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/serving-tests.json
@@ -422,8 +422,7 @@
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 4096,
-            "gpu_memory_utilization": 0.95
+            "max_model_len": 4096
         },
         "client_parameters": {
             "model": "",

--- a/vllm-benchmarks/benchmarks/cuda/serving-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/serving-tests.json
@@ -437,7 +437,7 @@
         "qps_list": [1, 4, 16, "inf"],
         "server_parameters": {
             "model": "openai/gpt-oss-120b",
-            "tensor_parallel_size": 1,
+            "tensor_parallel_size": 2,
             "swap_space": 16,
             "disable_log_stats": "",
             "disable_log_requests": "",

--- a/vllm-benchmarks/benchmarks/cuda/serving-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/serving-tests.json
@@ -422,8 +422,7 @@
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 8192,
-            "gpu_memory_utilization": 0.95
+            "max_model_len": 4096
         },
         "client_parameters": {
             "model": "",
@@ -443,7 +442,7 @@
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 8192
+            "max_model_len": 4096
         },
         "client_parameters": {
             "model": "",
@@ -463,7 +462,7 @@
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 8192
+            "max_model_len": 4096
         },
         "client_parameters": {
             "model": "",

--- a/vllm-benchmarks/benchmarks/cuda/serving-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/serving-tests.json
@@ -422,7 +422,8 @@
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 8192
+            "max_model_len": 8192,
+            "gpu_memory_utilization": 0.95
         },
         "client_parameters": {
             "model": "",

--- a/vllm-benchmarks/benchmarks/cuda/serving-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/serving-tests.json
@@ -425,7 +425,7 @@
             "max_model_len": 8192
         },
         "client_parameters": {
-            "model": "",
+            "model": "openai/gpt-oss-20b",
             "backend": "vllm",
             "dataset_name": "sharegpt",
             "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",
@@ -445,7 +445,7 @@
             "max_model_len": 8192
         },
         "client_parameters": {
-            "model": "",
+            "model": "openai/gpt-oss-120b",
             "backend": "vllm",
             "dataset_name": "sharegpt",
             "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",
@@ -465,7 +465,7 @@
             "max_model_len": 8192
         },
         "client_parameters": {
-            "model": "",
+            "model": "openai/gpt-oss-120b",
             "backend": "vllm",
             "dataset_name": "sharegpt",
             "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",

--- a/vllm-benchmarks/benchmarks/cuda/serving-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/serving-tests.json
@@ -422,7 +422,8 @@
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 4096
+            "max_model_len": 4096,
+            "gpu_memory_utilization": 0.95
         },
         "client_parameters": {
             "model": "",

--- a/vllm-benchmarks/benchmarks/cuda/serving-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/serving-tests.json
@@ -411,5 +411,65 @@
             "random_input_len": 30720,
             "random_output_len": 100
         }
+    },
+    {
+        "test_name": "serving_gpt_oss_20b_tp1_sharegpt",
+        "qps_list": [1, 4, 16, "inf"],
+        "server_parameters": {
+            "model": "openai/gpt-oss-20b",
+            "tensor_parallel_size": 1,
+            "swap_space": 16,
+            "disable_log_stats": "",
+            "disable_log_requests": "",
+            "load_format": "dummy",
+            "max_model_len": 8192
+        },
+        "client_parameters": {
+            "model": "",
+            "backend": "vllm",
+            "dataset_name": "sharegpt",
+            "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200
+        }
+    },
+    {
+        "test_name": "serving_gpt_oss_120b_tp2_sharegpt",
+        "qps_list": [1, 4, 16, "inf"],
+        "server_parameters": {
+            "model": "openai/gpt-oss-120b",
+            "tensor_parallel_size": 1,
+            "swap_space": 16,
+            "disable_log_stats": "",
+            "disable_log_requests": "",
+            "load_format": "dummy",
+            "max_model_len": 8192
+        },
+        "client_parameters": {
+            "model": "",
+            "backend": "vllm",
+            "dataset_name": "sharegpt",
+            "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200
+        }
+    },
+    {
+        "test_name": "serving_gpt_oss_120b_tp4_sharegpt",
+        "qps_list": [1, 4, 16, "inf"],
+        "server_parameters": {
+            "model": "openai/gpt-oss-120b",
+            "tensor_parallel_size": 4,
+            "swap_space": 16,
+            "disable_log_stats": "",
+            "disable_log_requests": "",
+            "load_format": "dummy",
+            "max_model_len": 8192
+        },
+        "client_parameters": {
+            "model": "",
+            "backend": "vllm",
+            "dataset_name": "sharegpt",
+            "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200
+        }
     }
 ]

--- a/vllm-benchmarks/benchmarks/cuda/serving-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/serving-tests.json
@@ -422,7 +422,7 @@
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 4096
+            "max_model_len": 8192
         },
         "client_parameters": {
             "model": "",
@@ -442,7 +442,7 @@
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 4096
+            "max_model_len": 8192
         },
         "client_parameters": {
             "model": "",
@@ -462,7 +462,7 @@
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 4096
+            "max_model_len": 8192
         },
         "client_parameters": {
             "model": "",

--- a/vllm-benchmarks/benchmarks/cuda/throughput-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/throughput-tests.json
@@ -55,5 +55,41 @@
             "backend": "vllm",
             "max_model_len": 8192
         }
+    },
+    {
+        "test_name": "throughput_gpt_oss_20b_tp1",
+        "parameters": {
+            "model": "openai/gpt-oss-20b",
+            "tensor_parallel_size": 1,
+            "load_format": "dummy",
+            "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200,
+            "backend": "vllm",
+            "max_model_len": 8192
+        }
+    },
+    {
+        "test_name": "throughput_gpt_oss_120b_tp2",
+        "parameters": {
+            "model": "openai/gpt-oss-120b",
+            "tensor_parallel_size": 2,
+            "load_format": "dummy",
+            "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200,
+            "backend": "vllm",
+            "max_model_len": 8192
+        }
+    },
+    {
+        "test_name": "throughput_gpt_oss_120b_tp4",
+        "parameters": {
+            "model": "openai/gpt-oss-120b",
+            "tensor_parallel_size": 4,
+            "load_format": "dummy",
+            "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200,
+            "backend": "vllm",
+            "max_model_len": 8192
+        }
     }
 ]

--- a/vllm-benchmarks/benchmarks/cuda/throughput-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/throughput-tests.json
@@ -65,7 +65,8 @@
             "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
             "num_prompts": 200,
             "backend": "vllm",
-            "max_model_len": 4096
+            "max_model_len": 4096,
+            "gpu_memory_utilization": 0.95
         }
     },
     {

--- a/vllm-benchmarks/benchmarks/cuda/throughput-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/throughput-tests.json
@@ -65,7 +65,8 @@
             "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
             "num_prompts": 200,
             "backend": "vllm",
-            "max_model_len": 8192
+            "max_model_len": 8192,
+            "gpu_memory_utilization": 0.95
         }
     },
     {

--- a/vllm-benchmarks/benchmarks/cuda/throughput-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/throughput-tests.json
@@ -65,7 +65,7 @@
             "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
             "num_prompts": 200,
             "backend": "vllm",
-            "max_model_len": 4096
+            "max_model_len": 8192
         }
     },
     {
@@ -77,7 +77,7 @@
             "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
             "num_prompts": 200,
             "backend": "vllm",
-            "max_model_len": 4096
+            "max_model_len": 8192
         }
     },
     {
@@ -89,7 +89,7 @@
             "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
             "num_prompts": 200,
             "backend": "vllm",
-            "max_model_len": 4096
+            "max_model_len": 8192
         }
     }
 ]

--- a/vllm-benchmarks/benchmarks/cuda/throughput-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/throughput-tests.json
@@ -65,8 +65,7 @@
             "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
             "num_prompts": 200,
             "backend": "vllm",
-            "max_model_len": 4096,
-            "gpu_memory_utilization": 0.95
+            "max_model_len": 4096
         }
     },
     {

--- a/vllm-benchmarks/benchmarks/cuda/throughput-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/throughput-tests.json
@@ -65,8 +65,7 @@
             "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
             "num_prompts": 200,
             "backend": "vllm",
-            "max_model_len": 8192,
-            "gpu_memory_utilization": 0.95
+            "max_model_len": 4096
         }
     },
     {
@@ -78,7 +77,7 @@
             "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
             "num_prompts": 200,
             "backend": "vllm",
-            "max_model_len": 8192
+            "max_model_len": 4096
         }
     },
     {
@@ -90,7 +89,7 @@
             "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
             "num_prompts": 200,
             "backend": "vllm",
-            "max_model_len": 8192
+            "max_model_len": 4096
         }
     }
 ]

--- a/vllm-benchmarks/benchmarks/rocm/latency-tests.json
+++ b/vllm-benchmarks/benchmarks/rocm/latency-tests.json
@@ -50,5 +50,38 @@
             "num_iters": 15,
             "max_model_len": 8192
         }
+    },
+    {
+        "test_name": "latency_gpt_oss_20b_tp1",
+        "parameters": {
+            "model": "openai/gpt-oss-20b",
+            "tensor_parallel_size": 1,
+            "load_format": "dummy",
+            "num_iters_warmup": 5,
+            "num_iters": 15,
+            "max_model_len": 8192
+        }
+    },
+    {
+        "test_name": "latency_gpt_oss_120b_tp2",
+        "parameters": {
+            "model": "openai/gpt-oss-120b",
+            "tensor_parallel_size": 2,
+            "load_format": "dummy",
+            "num_iters_warmup": 5,
+            "num_iters": 15,
+            "max_model_len": 8192
+        }
+    },
+    {
+        "test_name": "latency_gpt_oss_120b_tp4",
+        "parameters": {
+            "model": "openai/gpt-oss-120b",
+            "tensor_parallel_size": 4,
+            "load_format": "dummy",
+            "num_iters_warmup": 5,
+            "num_iters": 15,
+            "max_model_len": 8192
+        }
     }
 ]

--- a/vllm-benchmarks/benchmarks/rocm/latency-tests.json
+++ b/vllm-benchmarks/benchmarks/rocm/latency-tests.json
@@ -72,5 +72,16 @@
             "num_iters": 15,
             "max_model_len": 8192
         }
+    },
+    {
+        "test_name": "latency_gpt_oss_120b_tp4",
+        "parameters": {
+            "model": "openai/gpt-oss-120b",
+            "tensor_parallel_size": 4,
+            "load_format": "dummy",
+            "num_iters_warmup": 5,
+            "num_iters": 15,
+            "max_model_len": 8192
+        }
     }
 ]

--- a/vllm-benchmarks/benchmarks/rocm/latency-tests.json
+++ b/vllm-benchmarks/benchmarks/rocm/latency-tests.json
@@ -59,7 +59,7 @@
             "load_format": "dummy",
             "num_iters_warmup": 5,
             "num_iters": 15,
-            "max_model_len": 8192
+            "max_model_len": 4096
         }
     },
     {
@@ -70,7 +70,7 @@
             "load_format": "dummy",
             "num_iters_warmup": 5,
             "num_iters": 15,
-            "max_model_len": 8192
+            "max_model_len": 4096
         }
     },
     {
@@ -81,7 +81,7 @@
             "load_format": "dummy",
             "num_iters_warmup": 5,
             "num_iters": 15,
-            "max_model_len": 8192
+            "max_model_len": 4096
         }
     }
 ]

--- a/vllm-benchmarks/benchmarks/rocm/latency-tests.json
+++ b/vllm-benchmarks/benchmarks/rocm/latency-tests.json
@@ -59,7 +59,7 @@
             "load_format": "dummy",
             "num_iters_warmup": 5,
             "num_iters": 15,
-            "max_model_len": 4096
+            "max_model_len": 8192
         }
     },
     {
@@ -70,7 +70,7 @@
             "load_format": "dummy",
             "num_iters_warmup": 5,
             "num_iters": 15,
-            "max_model_len": 4096
+            "max_model_len": 8192
         }
     },
     {
@@ -81,7 +81,7 @@
             "load_format": "dummy",
             "num_iters_warmup": 5,
             "num_iters": 15,
-            "max_model_len": 4096
+            "max_model_len": 8192
         }
     }
 ]

--- a/vllm-benchmarks/benchmarks/rocm/latency-tests.json
+++ b/vllm-benchmarks/benchmarks/rocm/latency-tests.json
@@ -72,16 +72,5 @@
             "num_iters": 15,
             "max_model_len": 8192
         }
-    },
-    {
-        "test_name": "latency_gpt_oss_120b_tp4",
-        "parameters": {
-            "model": "openai/gpt-oss-120b",
-            "tensor_parallel_size": 4,
-            "load_format": "dummy",
-            "num_iters_warmup": 5,
-            "num_iters": 15,
-            "max_model_len": 8192
-        }
     }
 ]

--- a/vllm-benchmarks/benchmarks/rocm/serving-tests.json
+++ b/vllm-benchmarks/benchmarks/rocm/serving-tests.json
@@ -425,7 +425,7 @@
             "compilation-config": "{'full_cuda_graph': true}"
         },
         "client_parameters": {
-            "model": "",
+            "model": "openai/gpt-oss-20b",
             "backend": "vllm",
             "dataset_name": "sharegpt",
             "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",
@@ -446,7 +446,7 @@
             "compilation-config": "{'full_cuda_graph': true}"
         },
         "client_parameters": {
-            "model": "",
+            "model": "openai/gpt-oss-120b",
             "backend": "vllm",
             "dataset_name": "sharegpt",
             "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",
@@ -467,7 +467,7 @@
             "compilation-config": "{'full_cuda_graph': true}"
         },
         "client_parameters": {
-            "model": "",
+            "model": "openai/gpt-oss-120b",
             "backend": "vllm",
             "dataset_name": "sharegpt",
             "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",

--- a/vllm-benchmarks/benchmarks/rocm/serving-tests.json
+++ b/vllm-benchmarks/benchmarks/rocm/serving-tests.json
@@ -421,7 +421,7 @@
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 8192,
+            "max_model_len": 4096,
             "compilation-config": "{'full_cuda_graph': true}"
         },
         "client_parameters": {
@@ -442,7 +442,7 @@
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 8192,
+            "max_model_len": 4096,
             "compilation-config": "{'full_cuda_graph': true}"
         },
         "client_parameters": {
@@ -463,7 +463,7 @@
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 8192,
+            "max_model_len": 4096,
             "compilation-config": "{'full_cuda_graph': true}"
         },
         "client_parameters": {

--- a/vllm-benchmarks/benchmarks/rocm/serving-tests.json
+++ b/vllm-benchmarks/benchmarks/rocm/serving-tests.json
@@ -436,8 +436,28 @@
         "qps_list": [1, 4, 16, "inf"],
         "server_parameters": {
             "model": "openai/gpt-oss-120b",
-            "tensor_parallel_size": 1,
-            "swap_space": 16,
+            "tensor_parallel_size": 2,
+            "swap_space": 128,
+            "disable_log_stats": "",
+            "disable_log_requests": "",
+            "load_format": "dummy",
+            "max_model_len": 8192
+        },
+        "client_parameters": {
+            "model": "",
+            "backend": "vllm",
+            "dataset_name": "sharegpt",
+            "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200
+        }
+    },
+    {
+        "test_name": "serving_gpt_oss_120b_tp4_sharegpt",
+        "qps_list": [1, 4, 16, "inf"],
+        "server_parameters": {
+            "model": "openai/gpt-oss-120b",
+            "tensor_parallel_size": 4,
+            "swap_space": 128,
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",

--- a/vllm-benchmarks/benchmarks/rocm/serving-tests.json
+++ b/vllm-benchmarks/benchmarks/rocm/serving-tests.json
@@ -450,25 +450,5 @@
             "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",
             "num_prompts": 200
         }
-    },
-    {
-        "test_name": "serving_gpt_oss_120b_tp4_sharegpt",
-        "qps_list": [1, 4, 16, "inf"],
-        "server_parameters": {
-            "model": "openai/gpt-oss-120b",
-            "tensor_parallel_size": 4,
-            "swap_space": 16,
-            "disable_log_stats": "",
-            "disable_log_requests": "",
-            "load_format": "dummy",
-            "max_model_len": 8192
-        },
-        "client_parameters": {
-            "model": "",
-            "backend": "vllm",
-            "dataset_name": "sharegpt",
-            "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",
-            "num_prompts": 200
-        }
     }
 ]

--- a/vllm-benchmarks/benchmarks/rocm/serving-tests.json
+++ b/vllm-benchmarks/benchmarks/rocm/serving-tests.json
@@ -421,7 +421,8 @@
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 8192
+            "max_model_len": 8192,
+            "compilation-config": "{'full_cuda_graph': true}"
         },
         "client_parameters": {
             "model": "",
@@ -437,11 +438,12 @@
         "server_parameters": {
             "model": "openai/gpt-oss-120b",
             "tensor_parallel_size": 2,
-            "swap_space": 128,
+            "swap_space": 16,
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 8192
+            "max_model_len": 8192,
+            "compilation-config": "{'full_cuda_graph': true}"
         },
         "client_parameters": {
             "model": "",
@@ -457,11 +459,12 @@
         "server_parameters": {
             "model": "openai/gpt-oss-120b",
             "tensor_parallel_size": 4,
-            "swap_space": 128,
+            "swap_space": 16,
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 8192
+            "max_model_len": 8192,
+            "compilation-config": "{'full_cuda_graph': true}"
         },
         "client_parameters": {
             "model": "",

--- a/vllm-benchmarks/benchmarks/rocm/serving-tests.json
+++ b/vllm-benchmarks/benchmarks/rocm/serving-tests.json
@@ -410,5 +410,68 @@
             "random_input_len": 1024,
             "random_output_len": 2048
         }
+    },
+    {
+        "test_name": "serving_gpt_oss_20b_tp1_sharegpt",
+        "qps_list": [1, 4, 16, "inf"],
+        "server_parameters": {
+            "model": "openai/gpt-oss-20b",
+            "tensor_parallel_size": 1,
+            "swap_space": 16,
+            "disable_log_stats": "",
+            "disable_log_requests": "",
+            "load_format": "dummy",
+            "max_model_len": 8192,
+            "compilation-config": "{'full_cuda_graph': true}"
+        },
+        "client_parameters": {
+            "model": "",
+            "backend": "vllm",
+            "dataset_name": "sharegpt",
+            "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200
+        }
+    },
+    {
+        "test_name": "serving_gpt_oss_120b_tp2_sharegpt",
+        "qps_list": [1, 4, 16, "inf"],
+        "server_parameters": {
+            "model": "openai/gpt-oss-120b",
+            "tensor_parallel_size": 1,
+            "swap_space": 16,
+            "disable_log_stats": "",
+            "disable_log_requests": "",
+            "load_format": "dummy",
+            "max_model_len": 8192,
+            "compilation-config": "{'full_cuda_graph': true}"
+        },
+        "client_parameters": {
+            "model": "",
+            "backend": "vllm",
+            "dataset_name": "sharegpt",
+            "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200
+        }
+    },
+    {
+        "test_name": "serving_gpt_oss_120b_tp4_sharegpt",
+        "qps_list": [1, 4, 16, "inf"],
+        "server_parameters": {
+            "model": "openai/gpt-oss-120b",
+            "tensor_parallel_size": 4,
+            "swap_space": 16,
+            "disable_log_stats": "",
+            "disable_log_requests": "",
+            "load_format": "dummy",
+            "max_model_len": 8192,
+            "compilation-config": "{'full_cuda_graph': true}"
+        },
+        "client_parameters": {
+            "model": "",
+            "backend": "vllm",
+            "dataset_name": "sharegpt",
+            "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200
+        }
     }
 ]

--- a/vllm-benchmarks/benchmarks/rocm/serving-tests.json
+++ b/vllm-benchmarks/benchmarks/rocm/serving-tests.json
@@ -421,8 +421,7 @@
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 4096,
-            "compilation-config": "{'full_cuda_graph': true}"
+            "max_model_len": 8192
         },
         "client_parameters": {
             "model": "",
@@ -442,8 +441,7 @@
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 4096,
-            "compilation-config": "{'full_cuda_graph': true}"
+            "max_model_len": 8192
         },
         "client_parameters": {
             "model": "",
@@ -463,8 +461,7 @@
             "disable_log_stats": "",
             "disable_log_requests": "",
             "load_format": "dummy",
-            "max_model_len": 4096,
-            "compilation-config": "{'full_cuda_graph': true}"
+            "max_model_len": 8192
         },
         "client_parameters": {
             "model": "",

--- a/vllm-benchmarks/benchmarks/rocm/throughput-tests.json
+++ b/vllm-benchmarks/benchmarks/rocm/throughput-tests.json
@@ -55,5 +55,41 @@
             "backend": "vllm",
             "max_model_len": 8192
         }
+    },
+    {
+        "test_name": "throughput_gpt_oss_20b_tp1",
+        "parameters": {
+            "model": "openai/gpt-oss-20b",
+            "tensor_parallel_size": 1,
+            "load_format": "dummy",
+            "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200,
+            "backend": "vllm",
+            "max_model_len": 8192
+        }
+    },
+    {
+        "test_name": "throughput_gpt_oss_120b_tp2",
+        "parameters": {
+            "model": "openai/gpt-oss-120b",
+            "tensor_parallel_size": 2,
+            "load_format": "dummy",
+            "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200,
+            "backend": "vllm",
+            "max_model_len": 8192
+        }
+    },
+    {
+        "test_name": "throughput_gpt_oss_120b_tp4",
+        "parameters": {
+            "model": "openai/gpt-oss-120b",
+            "tensor_parallel_size": 4,
+            "load_format": "dummy",
+            "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200,
+            "backend": "vllm",
+            "max_model_len": 8192
+        }
     }
 ]

--- a/vllm-benchmarks/benchmarks/rocm/throughput-tests.json
+++ b/vllm-benchmarks/benchmarks/rocm/throughput-tests.json
@@ -65,7 +65,7 @@
             "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
             "num_prompts": 200,
             "backend": "vllm",
-            "max_model_len": 8192
+            "max_model_len": 4096
         }
     },
     {
@@ -77,7 +77,7 @@
             "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
             "num_prompts": 200,
             "backend": "vllm",
-            "max_model_len": 8192
+            "max_model_len": 4096
         }
     },
     {
@@ -89,7 +89,7 @@
             "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
             "num_prompts": 200,
             "backend": "vllm",
-            "max_model_len": 8192
+            "max_model_len": 4096
         }
     }
 ]

--- a/vllm-benchmarks/benchmarks/rocm/throughput-tests.json
+++ b/vllm-benchmarks/benchmarks/rocm/throughput-tests.json
@@ -65,7 +65,7 @@
             "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
             "num_prompts": 200,
             "backend": "vllm",
-            "max_model_len": 4096
+            "max_model_len": 8192
         }
     },
     {
@@ -77,7 +77,7 @@
             "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
             "num_prompts": 200,
             "backend": "vllm",
-            "max_model_len": 4096
+            "max_model_len": 8192
         }
     },
     {
@@ -89,7 +89,7 @@
             "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
             "num_prompts": 200,
             "backend": "vllm",
-            "max_model_len": 4096
+            "max_model_len": 8192
         }
     }
 ]

--- a/vllm-benchmarks/benchmarks/rocm/throughput-tests.json
+++ b/vllm-benchmarks/benchmarks/rocm/throughput-tests.json
@@ -79,17 +79,5 @@
             "backend": "vllm",
             "max_model_len": 8192
         }
-    },
-    {
-        "test_name": "throughput_gpt_oss_120b_tp4",
-        "parameters": {
-            "model": "openai/gpt-oss-120b",
-            "tensor_parallel_size": 4,
-            "load_format": "dummy",
-            "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
-            "num_prompts": 200,
-            "backend": "vllm",
-            "max_model_len": 8192
-        }
     }
 ]

--- a/vllm-benchmarks/benchmarks/rocm/throughput-tests.json
+++ b/vllm-benchmarks/benchmarks/rocm/throughput-tests.json
@@ -79,5 +79,17 @@
             "backend": "vllm",
             "max_model_len": 8192
         }
+    },
+    {
+        "test_name": "throughput_gpt_oss_120b_tp4",
+        "parameters": {
+            "model": "openai/gpt-oss-120b",
+            "tensor_parallel_size": 4,
+            "load_format": "dummy",
+            "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200,
+            "backend": "vllm",
+            "max_model_len": 8192
+        }
     }
 ]


### PR DESCRIPTION
On 8xH100 and 8xB200, here are the current numbers for the two models:

### gpt-oss-20b
```
+-----------------+-------+-------+--------+
|                 | b200  | h100  | mi325x |
+-----------------+-------+-------+--------+
| gpqa (low)      | 0.568 | 0.580 | n/a    |
| gpqa (medium)   | 0.662 | 0.670 | n/a    |
| gpqa (high)     | 0.729 | 0.735 | n/a    |
+-----------------+-------+-------+--------+
| aime25 (low)    | 0.333 | 0.342 | n/a    |
| aime25 (medium) | 0.717 | 0.737 | n/a    |
| aime25 (high)   | 0.858 | 0.842 | n/a    |
+-----------------+-------+-------+--------+
```

[gpt-oss-20b perf numbers](https://hud.pytorch.org/benchmark/llms?startTime=Fri%2C%2001%20Aug%202025%2018%3A40%3A55%20GMT&stopTime=Fri%2C%2008%20Aug%202025%2018%3A40%3A55%20GMT&granularity=day&lBranch=main&lCommit=f0964e29cb3b2deccdad89f5f8c068d3a629d239&rBranch=main&rCommit=f0964e29cb3b2deccdad89f5f8c068d3a629d239&repoName=vllm-project%2Fvllm&benchmarkName=&modelName=openai%2Fgpt-oss-20b&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=cuda%20(NVIDIA%20B200)&archName=All%20Platforms)

### gpt-oss-120b
```
+-----------------+-------+-------+--------+
|                 | b200  | h100  | mi325x |
+-----------------+-------+-------+--------+
| gpqa (low)      | 0.653 | 0.654 | n/a    |
| gpqa (medium)   | 0.718 | 0.713 | n/a    |
| gpqa (high)     | 0.785 | 0.786 | n/a    |
+-----------------+-------+-------+--------+
| aime25 (low)    | 0.512 | 0.500 | n/a    |
| aime25 (medium) | 0.754 | 0.758 | n/a    |
| aime25 (high)   | 0.883 | 0.921 | n/a    |
+-----------------+-------+-------+--------+

```

[gpt-oss-120b perf numbers](https://hud.pytorch.org/benchmark/llms?startTime=Fri%2C%2001%20Aug%202025%2018%3A40%3A55%20GMT&stopTime=Fri%2C%2008%20Aug%202025%2018%3A40%3A55%20GMT&granularity=day&lBranch=main&lCommit=f0964e29cb3b2deccdad89f5f8c068d3a629d239&rBranch=main&rCommit=f0964e29cb3b2deccdad89f5f8c068d3a629d239&repoName=vllm-project%2Fvllm&benchmarkName=&modelName=openai%2Fgpt-oss-120b&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=cuda%20(NVIDIA%20B200)&archName=All%20Platforms)

Overall, the accuracy scores are on the same par as https://docs.vllm.ai/projects/recipes/en/latest/OpenAI/GPT-OSS.html#accuracy-evaluation-panels for H100, but `aime25` results on B200 looks like there are issues there.

Here are the links to download the raw results:
* `gpqa` accuracy https://github.com/pytorch/pytorch-integration-testing/actions/runs/16823595241
* `aime25` accuracy https://github.com/pytorch/pytorch-integration-testing/actions/runs/16839593742