### PR TITLE
Fix the login to public.ecr.aws from DGX runners 

### DIFF
--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -161,6 +161,17 @@ jobs:
           echo "DOCKER_IMAGE_PREFIX=$DOCKER_IMAGE_PREFIX" >> $GITHUB_ENV
           echo "DOCKER_IMAGE_SUFFIX=$DOCKER_IMAGE_SUFFIX" >> $GITHUB_ENV
 
+      - name: Login to public.ecr.aws
+        # Only need for DGX hosts
+        if: contains(env.DEVICE_TYPE, 'B200')
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          aws configure set aws_access_key_id "${AWS_ACCESS_KEY_ID}"
+          aws configure set aws_secret_access_key "${AWS_SECRET_ACCESS_KEY}"
+          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+
       - name: Check for last benchmark commit
         working-directory: vllm-benchmarks
         env:

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -25,7 +25,7 @@ on:
           A comma-separated list of runners from .github/scripts/generate_vllm_benchmark_matrix.py to run the benchmark (optional, default to run everything)
         required: true
         type: string
-        default: h100,mi300,spr
+        default: h100,rocm,spr,b200
   pull_request:
     paths:
       - .github/workflows/vllm-benchmark.yml

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -161,16 +161,21 @@ jobs:
           echo "DOCKER_IMAGE_PREFIX=$DOCKER_IMAGE_PREFIX" >> $GITHUB_ENV
           echo "DOCKER_IMAGE_SUFFIX=$DOCKER_IMAGE_SUFFIX" >> $GITHUB_ENV
 
+      - name: Authenticate with AWS
+        # Only need for DGX hosts
+        if: contains(env.DEVICE_TYPE, 'B200')
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/public_ecr_read_only
+          role-duration-seconds: 18000
+          aws-region: us-east-1
+
       - name: Login to public.ecr.aws
         # Only need for DGX hosts
         if: contains(env.DEVICE_TYPE, 'B200')
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: |
-          aws configure set aws_access_key_id "${AWS_ACCESS_KEY_ID}"
-          aws configure set aws_secret_access_key "${AWS_SECRET_ACCESS_KEY}"
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        with:
+          registry-type: public
 
       - name: Check for last benchmark commit
         working-directory: vllm-benchmarks


### PR DESCRIPTION
The host is rate limited if not logging in https://github.com/pytorch/pytorch-integration-testing/actions/runs/16782275503/job/47559587865#step:9:59.  I also update the runners option to include `b200`.  This depends on the OIDC role from https://github.com/meta-pytorch/pytorch-gha-infra/pull/778

### Testing

https://github.com/pytorch/pytorch-integration-testing/actions/runs/16793975562