### PR TITLE
[SGLang Workflow] Upload benchmark results to S3 and Clickhouse

### DIFF
--- a/.github/workflows/sglang-benchmark.yml
+++ b/.github/workflows/sglang-benchmark.yml
@@ -238,6 +238,14 @@ jobs:
             echo "⚠️ No benchmark results found in ${BENCHMARK_RESULTS}" >> $GITHUB_STEP_SUMMARY
           fi
 
+          python3 .github/scripts/upload_benchmark_results.py \
+              --repo sglang-benchmarks/sglang \
+              --benchmark-name "SGLang benchmark" \
+              --benchmark-results "${BENCHMARK_RESULTS}" \
+              --device-name "${DEVICE_NAME}" \
+              --device-type "${SANITIZED_DEVICE_TYPE}" \
+              --model "${SANITIZED_MODELS}"
+
           echo "SANITIZED_DEVICE_TYPE=$SANITIZED_DEVICE_TYPE" >> $GITHUB_ENV
           echo "SANITIZED_MODELS=$SANITIZED_MODELS" >> $GITHUB_ENV
 


### PR DESCRIPTION
These changes upload the SGLang benchmark results to the AWS S3 bucket, which internally triggers the AWS Lambda function to upload them to the clickhouse database. Eventually, being rendered in the HUD Dashboard.