### PR TITLE
[SGlang] [Fix] Removing Torch dynamo environment variable dependency from the SGLang server

### DIFF
--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -202,7 +202,7 @@ run_serving_tests() {
       continue
     fi
 
-    server_command="${SGLANG_SERVER_PY:-python3} -m sglang.launch_server --model-path $model_path --context-length $context_length --tp $tp"
+    server_command="${SGLANG_SERVER_PY:-python} -m sglang.launch_server --model-path $model_path --context-length $context_length --tp $tp"
 
     # run the server
     echo "Running test case $test_name"

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -202,7 +202,7 @@ run_serving_tests() {
       continue
     fi
 
-    server_command="${SGLANG_SERVER_PY:-python3} -m sglang.launch_server --model-path $model_path --context-length $context_length --tp $tp"
+    server_command="python -m sglang.launch_server --model-path $model_path --context-length $context_length --tp $tp"
 
     # run the server
     echo "Running test case $test_name"

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -202,7 +202,7 @@ run_serving_tests() {
       continue
     fi
 
-    server_command="python3 -m sglang.launch_server --model-path $model_path --context-length $context_length --tp $tp"
+    server_command="${SGLANG_SERVER_PY:-python3} -m sglang.launch_server --model-path $model_path --context-length $context_length --tp $tp"
 
     # run the server
     echo "Running test case $test_name"

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -202,7 +202,7 @@ run_serving_tests() {
       continue
     fi
 
-    server_command="${SGLANG_SERVER_PY:-python} -m sglang.launch_server --model-path $model_path --context-length $context_length --tp $tp"
+    server_command="${SGLANG_SERVER_PY:-python3} -m sglang.launch_server --model-path $model_path --context-length $context_length --tp $tp"
 
     # run the server
     echo "Running test case $test_name"

--- a/.github/workflows/sglang-benchmark.yml
+++ b/.github/workflows/sglang-benchmark.yml
@@ -179,10 +179,10 @@ jobs:
           uv venv sgl_server_env
 
           # Install SGLang from source
-          uv pip install -p sgl_server_env -e "$(pwd)/sglang/python[all]"
+          uv pip install -p sgl_server_env -e "$(pwd)/sglang/python[all]" boto3 psutil gitpython
 
           # Verify installations
-          echo "SGLANG_SERVER_PY=$(pwd)/sgl_server_env/bin/python" >> $GITHUB_ENV
+          echo "$(pwd)/sgl_server_env/bin" >> $GITHUB_PATH
 
       - name: Setup benchmark tests
         env:
@@ -209,7 +209,6 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           SAVE_TO_PYTORCH_BENCHMARK_FORMAT: 1
-          SGLANG_SERVER_PY: ${{ env.SGLANG_SERVER_PY }}
         run: |
           set -eux
           bash ../../.github/scripts/run-sglang-performance-benchmarks.sh

--- a/.github/workflows/sglang-benchmark.yml
+++ b/.github/workflows/sglang-benchmark.yml
@@ -178,14 +178,11 @@ jobs:
           set -eux
           uv venv sgl_server_env
 
-          SGL_PY="$(pwd)/sgl_server_env/bin/python"
-          SGL_PIP="$(pwd)/sgl_server_env/bin/pip"
-
           # Install SGLang from source
-          $SGL_PIP install -e "$(pwd)/sglang/python[all]"
+          uv pip install -p sgl_server_env -e "$(pwd)/sglang/python[all]"
 
           # Verify installations
-          echo "SGLANG_SERVER_PY=$SGL_PY" >> $GITHUB_ENV
+          echo "SGLANG_SERVER_PY=$(pwd)/sgl_server_env/bin/python" >> $GITHUB_ENV
 
       - name: Setup benchmark tests
         env:

--- a/.github/workflows/sglang-benchmark.yml
+++ b/.github/workflows/sglang-benchmark.yml
@@ -176,13 +176,17 @@ jobs:
         shell: bash
         run: |
           set -eux
+          uv venv sgl_server_env
+          . sgl_server_env/bin/activate
 
           # Install SGLang from source
           pushd sglang
           pip install -e "python[all]"
+          popd
 
           # Verify installations
           python3 -c "import sglang; print('SGLang installed successfully')"
+          echo "SGLANG_SERVER_PY=$(pwd)/sgl_server_env/bin/python" >> $GITHUB_ENV
 
       - name: Setup benchmark tests
         env:
@@ -209,7 +213,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           SAVE_TO_PYTORCH_BENCHMARK_FORMAT: 1
-          TORCHDYNAMO_DISABLE: "1" #TODO: remove this variable in future. As of now, this is a workaround to fix cuda errors to avoid breaking the sglang server.
+          SGLANG_SERVER_PY: ${{ env.SGLANG_SERVER_PY }}
         run: |
           set -eux
           bash ../../.github/scripts/run-sglang-performance-benchmarks.sh

--- a/.github/workflows/sglang-benchmark.yml
+++ b/.github/workflows/sglang-benchmark.yml
@@ -177,16 +177,15 @@ jobs:
         run: |
           set -eux
           uv venv sgl_server_env
-          . sgl_server_env/bin/activate
+
+          SGL_PY="$(pwd)/sgl_server_env/bin/python"
+          SGL_PIP="$(pwd)/sgl_server_env/bin/pip"
 
           # Install SGLang from source
-          pushd sglang
-          pip install -e "python[all]"
-          popd
+          $SGL_PIP install -e "$(pwd)/sglang/python[all]"
 
           # Verify installations
-          python3 -c "import sglang; print('SGLang installed successfully')"
-          echo "SGLANG_SERVER_PY=$(pwd)/sgl_server_env/bin/python" >> $GITHUB_ENV
+          echo "SGLANG_SERVER_PY=$SGL_PY" >> $GITHUB_ENV
 
       - name: Setup benchmark tests
         env:

--- a/.github/workflows/sglang-benchmark.yml
+++ b/.github/workflows/sglang-benchmark.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           repository: sgl-project/sglang
           path: sglang-benchmarks/sglang
-          ref: ${{ inputs.sglang_branch || 'main' }}
+          ref: ${{ inputs.sglang_branch || 'v0.5.1.post2' }}
           fetch-depth: 0
 
       - uses: actions/setup-python@v5


### PR DESCRIPTION
This PR involves removing the `TORCHDYNAMO_DISABLE` flag whenever we run the SGLang benchmarks.

**Problem**:  The SGLang and vLLM libraries were having compatibility issues for the Triton library leading to killing of the SGLang server when running through the benchmark.

**Solution**: We are isolating the SGLang server as well in a separate virtual environment, so that there are no dependencies of libraries on each other, and since vLLM's load gen script interacts with the server through the REST protocol, this arrangement works perfectly fine.

**Testing**: Verified through the Github actions that all the serving tests with multiple QPS iterations are working fine.
Link: https://github.com/pytorch/pytorch-integration-testing/actions/runs/17333991856/job/49216326357?pr=71
