### PR TITLE
[Fix] [SGLang] Set default branch to main for SGLang workflow

### DIFF
--- a/.github/workflows/sglang-benchmark.yml
+++ b/.github/workflows/sglang-benchmark.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           repository: sgl-project/sglang
           path: sglang-benchmarks/sglang
-          ref: ${{ inputs.sglang_branch || 'v0.5.1.post2' }}
+          ref: ${{ inputs.sglang_branch || 'main' }}
           fetch-depth: 0
 
       - uses: actions/setup-python@v5
@@ -126,6 +126,8 @@ jobs:
 
           if [[ "${DEVICE_NAME}" == "cuda" ]]; then
             DEVICE_TYPE=$(nvidia-smi -i 0 --query-gpu=name --format=csv,noheader | awk '{print $2}')
+            CUDA_HOME="/usr/local/cuda"
+            echo "CUDA_HOME=$CUDA_HOME" >> $GITHUB_ENV
           elif [[ "${DEVICE_NAME}" == "rocm" ]]; then
             DEVICE_TYPE=$(rocminfo | grep "Marketing Name" | tail -n1 | awk -F':' '{print $2}' | xargs)
           elif [[ "${DEVICE_NAME}" == "cpu" ]]; then


### PR DESCRIPTION
This PR updates the default branch in the SGLang workflow to "main", and setting the CUDA_HOME fixes a small issue in the workflow.

Context: There was some issue in the "main" branch in the SGLang framework codebase. Due to that, we were not able to integrate our Github workflow end-to-end, so we temporarily set the default branch to some release branch.

**Testing:**

* Verified through the HUD dashboard that the latest commits are reflecting correctly.
https://hud.pytorch.org/benchmark/llms?repoName=sgl-project%2Fsglang

<img width="2012" height="1181" alt="Screenshot 2025-09-02 at 3 39 59 PM" src="https://github.com/user-attachments/assets/e10a995c-a816-45d8-b0b7-72d813461216" />


* Github actions are working fine: https://github.com/pytorch/pytorch-integration-testing/actions/runs/17417515887/job/49449172041?pr=73