### PR TITLE
[HUD] [SGLang benchmarking] Adding bigger models for NVIDIA and implementing AMD Support for SGLang using docker

### DIFF
--- a/.github/scripts/generate_vllm_benchmark_matrix.py
+++ b/.github/scripts/generate_vllm_benchmark_matrix.py
@@ -80,6 +80,7 @@ PLATFORM_SKIPS = {
     ],
     "google/gemma-3-4b-it": [
         "linux.dgx.b200",
+        "linux.rocm.gpu.gfx942",  # TODO: Fail on ROCm
     ],
     # Run some bigger models on B200 to share the load
     "Qwen/Qwen3-30B-A3B": [

--- a/.github/scripts/generate_vllm_benchmark_matrix.py
+++ b/.github/scripts/generate_vllm_benchmark_matrix.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-import os
-import json
 import glob
+import json
 import logging
-from logging import warning
+import os
 from argparse import Action, ArgumentParser, Namespace
-from typing import Any, Dict, Optional, List
+from logging import warning
+from typing import Any, Dict, List, Optional
 
 
 logging.basicConfig(level=logging.INFO)
@@ -45,6 +45,7 @@ RUNNER_TO_PLATFORM_MAPPING = {
     "linux.aws.h100.8": "cuda",
     "linux.dgx.b200": "cuda",
     "linux.dgx.b200.8": "cuda",
+    "linux.rocm.gpu.gfx942.1": "rocm",
     "linux.rocm.gpu.gfx942.2": "rocm",
     "linux.rocm.gpu.gfx942.4": "rocm",
     "linux.rocm.gpu.gfx942.8": "rocm",

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -90,6 +90,7 @@ run_serving_tests() {
     # Extract only specific SGLang server parameters
     model_path=$(echo "$server_params" | jq -r '.model_path // .model')
     context_length=$(echo "$server_params" | jq -r '.context_length // 4096')
+    load_format=$(echo "$server_params" | jq -r '.load_format // "dummy"')
 
     # check if there is enough resources to run the test
     tp=$(echo "$server_params" | jq -r '.tp // 1')
@@ -113,7 +114,7 @@ run_serving_tests() {
       continue
     fi
 
-    server_command="python3 -m sglang.launch_server --model-path $model_path --context-length $context_length --tp $tp"
+    server_command="python3 -m sglang.launch_server --model-path $model_path --context-length $context_length --tp $tp --load-format $load_format"
 
     # run the server
     echo "Running test case $test_name"

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -114,16 +114,7 @@ run_serving_tests() {
       continue
     fi
 
-    server_env_prefix=""
-    if [[ "${DEVICE_NAME:-}" == "rocm" ]]; then
-      # TorchInductor in ROCm containers can be out of sync with the Triton
-      # runtime that ships alongside the Docker image. Disable Dynamo/Inductor
-      # so we fall back to eager mode instead of crashing when the worker
-      # imports the Triton heuristics module.
-      server_env_prefix+="TORCHINDUCTOR_DISABLE=1 TORCHDYNAMO_DISABLE=1 "
-    fi
-
-    server_command="${server_env_prefix}python3 -m sglang.launch_server --model-path $model_path --context-length $context_length --tp $tp --load-format $load_format"
+    server_command="python3 -m sglang.launch_server --model-path $model_path --context-length $context_length --tp $tp --load-format $load_format"
 
     # run the server
     echo "Running test case $test_name"
@@ -153,12 +144,12 @@ run_serving_tests() {
       # Allow callers to override the index URL, but default to the ROCm 6.3
       # index that matches the Docker image we use in CI.
       extra_index="${PYTORCH_ROCM_INDEX_URL:-https://download.pytorch.org/whl/rocm6.3}"
-      pip install --no-cache-dir --upgrade --force-reinstall \
+      uv pip install --no-cache-dir --upgrade --force-reinstall \
         --index-url "${extra_index}" \
         --extra-index-url https://pypi.org/simple \
         vllm
     else
-      pip install vllm
+      uv pip install vllm
     fi
 
     # iterate over different QPS

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -144,12 +144,12 @@ run_serving_tests() {
       # Allow callers to override the index URL, but default to the ROCm 6.3
       # index that matches the Docker image we use in CI.
       extra_index="${PYTORCH_ROCM_INDEX_URL:-https://download.pytorch.org/whl/rocm6.3}"
-      python -m pip install --no-cache-dir --upgrade --force-reinstall \
+      pip install --no-cache-dir --upgrade --force-reinstall \
         --index-url "${extra_index}" \
         --extra-index-url https://pypi.org/simple \
         vllm
     else
-      python -m pip install vllm
+      pip install vllm
     fi
 
     # iterate over different QPS

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -81,7 +81,26 @@ build_vllm_from_source_rocm() {
   export LD_LIBRARY_PATH="/opt/rocm/lib:$LD_LIBRARY_PATH"
 
   # 7) Build & install vLLM into this venv
-  python3 setup.py develop
+  
+  # Check if ROCm is properly detected
+  echo "Checking ROCm installation..."
+  which hipcc || echo "hipcc not found in PATH"
+  which rocminfo || echo "rocminfo not found in PATH"
+  rocminfo || echo "rocminfo failed"
+  
+  # Try alternative installation methods for ROCm
+  echo "Attempting to install vLLM for ROCm..."
+  
+  # Method 1: Try pip install with ROCm support
+  if uv pip install vllm --extra-index-url https://download.pytorch.org/whl/rocm6.3; then
+    echo "Successfully installed vLLM via pip"
+  else
+    echo "Pip install failed, trying setup.py develop..."
+    
+    # Method 2: Try setup.py develop with explicit ROCm environment
+    VLLM_TARGET_DEVICE=rocm python3 setup.py develop
+  fi
+  
   cd ..
 }
 

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -202,8 +202,29 @@ run_serving_tests() {
       continue
     fi
 
-    # Build the server command with ROCm-specific optimizations for DeepSeek models
+    # Build the server command
     server_command="python3 -m sglang.launch_server --model-path $model_path --context-length $context_length --tp $tp --load-format $load_format --dtype $dtype"
+    
+    # Add model-specific compatibility flags
+    if [[ "${DEVICE_NAME:-}" == "rocm" ]]; then
+      # DeepSeek models on ROCm
+      if [[ "$model_path" == *"DeepSeek"* ]]; then
+        echo "Detected DeepSeek model on ROCm, adding AMD-recommended compatibility flags"
+        # Set AMD-recommended environment variables for ROCm performance
+        export DEBUG_HIP_BLOCK_SYNC=1024
+        export GPU_FORCE_BLIT_COPY_SIZE=6
+        # Use AMD's official configuration for DeepSeek models on ROCm
+        server_command="$server_command --disable-radix-cache --trust-remote-code"
+      fi
+      
+      # GPT-OSS models on ROCm - disable AITER to avoid GEMM errors
+      if [[ "$model_path" == *"gpt-oss"* ]]; then
+        echo "Detected GPT-OSS model on ROCm, disabling AITER to avoid GEMM compatibility issues"
+        export SGLANG_USE_AITER=0
+        # Use triton attention backend for better compatibility
+        server_command="$server_command --attention-backend triton --trust-remote-code"
+      fi
+    fi
     # run the server
     echo "Running test case $test_name"
     echo "Server command: $server_command"

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -197,7 +197,7 @@ run_serving_tests() {
     # check if server model and client model is aligned
     server_model="$model_path"
     client_model=$(echo "$client_params" | jq -r '.model // .model_path')
-    if [[ $server_model != "$client_model" ]]; then
+    if [[ $server_model != "$client_model" ]] && [[ $server_model != *"gpt-oss"* ]]; then
       echo "Server model and client model must be the same. Skip testcase $test_name."
       continue
     fi

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -210,13 +210,6 @@ run_serving_tests() {
     
     # Model-specific environment variables (command-line flags can be added to JSON directly)
     if [[ "${DEVICE_NAME:-}" == "rocm" ]]; then
-      # DeepSeek models on ROCm - set environment variables
-      if [[ "$model_path" == *"DeepSeek"* ]]; then
-        echo "Detected DeepSeek model on ROCm, setting AMD-recommended environment variables"
-        export DEBUG_HIP_BLOCK_SYNC=1024
-        export GPU_FORCE_BLIT_COPY_SIZE=6
-      fi
-      
       # GPT-OSS models on ROCm - set environment variables
       if [[ "$model_path" == *"gpt-oss"* ]]; then
         echo "Detected GPT-OSS model on ROCm, setting compatibility environment variables"

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -44,8 +44,8 @@ ensure_vllm_installed() {
   echo "Installing vLLM..."
   python3 -m pip install --upgrade pip
   if [[ "$DEVICE_NAME" == "rocm" ]]; then
-    extra_index="${PYTORCH_ROCM_INDEX_URL:-https://download.pytorch.org/whl/rocm6.3}"
-    pip install --extra-index-url "${extra_index}" vllm-rocm
+    python3 -m pip install "vllm-rocm>=0.9" \
+      --extra-index-url https://download.pytorch.org/whl/rocm6.3
   else
     python3 -m pip install vllm
   fi
@@ -145,15 +145,15 @@ run_serving_tests() {
       new_test_name=$test_name"_qps_"$qps
       echo " new test name $new_test_name"
 
-      if vllm bench serve --help >/dev/null 2>&1; then
-        client_cmd_prefix="vllm bench serve"
-      else
-        client_cmd_prefix="python -m vllm.benchmarks.serve"
-      fi
+      # if vllm bench serve --help >/dev/null 2>&1; then
+      #   client_cmd_prefix="vllm bench serve"
+      # else
+      #   client_cmd_prefix="python -m vllm.benchmarks.serve"
+      # fi
 
       # pass the tensor parallel size to the client so that it can be displayed
       # on the benchmark dashboard
-      client_command="$client_cmd_prefix \
+      client_command="vllm bench serve \
         --save-result \
         --result-dir $RESULTS_FOLDER \
         --result-filename ${new_test_name}.json \

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -144,9 +144,12 @@ run_serving_tests() {
       # Allow callers to override the index URL, but default to the ROCm 6.3
       # index that matches the Docker image we use in CI.
       extra_index="${PYTORCH_ROCM_INDEX_URL:-https://download.pytorch.org/whl/rocm6.3}"
-      pip install --index-url "${extra_index}" --extra-index-url https://pypi.org/simple vllm
+      python3 -m pip install --no-cache-dir --upgrade --force-reinstall \
+        --index-url "${extra_index}" \
+        --extra-index-url https://pypi.org/simple \
+        vllm
     else
-      pip install vllm
+      python3 -m pip install vllm
     fi
 
     # iterate over different QPS

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -61,10 +61,11 @@ build_vllm_from_source_rocm() {
   fi
 
   # 5) Compile for GPU architectures
+  export VLLM_TARGET_DEVICE=rocm
   export PYTORCH_ROCM_ARCH="gfx90a;gfx942"
 
   # 6) Build & install vLLM into this venv
-  uv run python setup.py develop
+  uv run --active -- python setup.py develop
   cd ..
 }
 

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -41,25 +41,25 @@ ensure_sharegpt_downloaded() {
 }
 
 
-ensure_vllm_installed() {
-  echo "Installing vLLM..."
-  python3 -m pip install --upgrade pip
-  python3 -m pip install vllm
-}
-
 # ensure_vllm_installed() {
 #   echo "Installing vLLM..."
 #   python3 -m pip install --upgrade pip
-#   if [[ "${DEVICE_NAME:-}" == "rocm" ]]; then
-#     echo "Detected ROCm, installing vLLM with bench extras from ROCm wheels"
-#     # Pin to a version that includes the `bench` CLI;
-#     python3 -m pip install "vllm[bench]>=0.9.0" \
-#       --extra-index-url https://download.pytorch.org/whl/rocm6.3
-#   else
-#     echo "Non-ROCm environment, installing vanilla vLLM (same as before)"
-#     python3 -m pip install vllm
-#   fi
+#   python3 -m pip install vllm
 # }
+
+ensure_vllm_installed() {
+  echo "Installing vLLM..."
+  python3 -m pip install --upgrade pip
+  if [[ "$DEVICE_NAME" == "rocm" ]]; then
+    echo "Detected ROCm, installing vLLM with bench extras from ROCm wheels"
+    # Pin to a version that includes the `bench` CLI;
+    python3 -m pip install "vllm[bench]>=0.9.0" \
+      --extra-index-url https://download.pytorch.org/whl/rocm6.3
+  else
+    echo "Non-ROCm environment, installing vanilla vLLM (same as before)"
+    python3 -m pip install vllm
+  fi
+}
 
 
 run_serving_tests() {
@@ -157,14 +157,7 @@ run_serving_tests() {
 
       # pass the tensor parallel size to the client so that it can be displayed
       # on the benchmark dashboard
-      if vllm bench --help >/dev/null 2>&1; then
-        VLLM_BENCH_CMD="vllm bench serve"
-      else
-        # Fallback to the module, which works even when the CLI entrypoint isn't registered
-        VLLM_BENCH_CMD="python3 -m vllm.entrypoints.cli.main bench serve"
-      fi
-
-      client_command="$VLLM_BENCH_CMD \
+      client_command="vllm bench serve \
         --save-result \
         --result-dir $RESULTS_FOLDER \
         --result-filename ${new_test_name}.json \

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -40,21 +40,15 @@ ensure_sharegpt_downloaded() {
   fi
 }
 
-
-# ensure_vllm_installed() {
-#   echo "Installing vLLM..."
-#   python3 -m pip install --upgrade pip
-#   python3 -m pip install vllm
-# }
-
 ensure_vllm_installed() {
   echo "Installing vLLM..."
   python3 -m pip install --upgrade pip
   if [[ "$DEVICE_NAME" == "rocm" ]]; then
-    echo "Detected ROCm, uninstalling older version of vllm"
-    python3 -m pip uninstall vllm -y
+    extra_index="${PYTORCH_ROCM_INDEX_URL:-https://download.pytorch.org/whl/rocm6.3}"
+    pip install --extra-index-url "${extra_index}" vllm-rocm
+  else
+    python3 -m pip install vllm
   fi
-  python3 -m pip install vllm
 }
 
 

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -44,8 +44,8 @@ ensure_vllm_installed() {
   echo "Installing vLLM..."
   python3 -m pip install --upgrade pip
   if [[ "$DEVICE_NAME" == "rocm" ]]; then
-    # extra_index="${PYTORCH_ROCM_INDEX_URL:-https://download.pytorch.org/whl/rocm6.3}"
-    python3 -m pip install --index-url https://pypi.org/simple vllm-rocm
+    extra_index="${PYTORCH_ROCM_INDEX_URL:-https://download.pytorch.org/whl/rocm6.3}"
+    python3 -m pip install --index-url "${extra_index}" --extra-index-url https://pypi.org/simple vllm
   else
     python3 -m pip install vllm
   fi

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -51,14 +51,10 @@ ensure_vllm_installed() {
   echo "Installing vLLM..."
   python3 -m pip install --upgrade pip
   if [[ "$DEVICE_NAME" == "rocm" ]]; then
-    echo "Detected ROCm, installing vLLM with bench extras from ROCm wheels"
-    # Pin to a version that includes the `bench` CLI;
-    python3 -m pip install "vllm[bench]>=0.5.2" \
-      --extra-index-url https://download.pytorch.org/whl/rocm6.3
-  else
-    echo "Non-ROCm environment, installing vanilla vLLM (same as before)"
-    python3 -m pip install vllm
+    echo "Detected ROCm, uninstalling older version of vllm"
+    python3 -m pip uninstall vllm -y
   fi
+  python3 -m pip install vllm
 }
 
 

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -144,12 +144,12 @@ run_serving_tests() {
       # Allow callers to override the index URL, but default to the ROCm 6.3
       # index that matches the Docker image we use in CI.
       extra_index="${PYTORCH_ROCM_INDEX_URL:-https://download.pytorch.org/whl/rocm6.3}"
-      python3 -m pip install --no-cache-dir --upgrade --force-reinstall \
+      python -m pip install --no-cache-dir --upgrade --force-reinstall \
         --index-url "${extra_index}" \
         --extra-index-url https://pypi.org/simple \
         vllm
     else
-      python3 -m pip install vllm
+      python -m pip install vllm
     fi
 
     # iterate over different QPS

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -44,7 +44,7 @@ build_vllm_from_source_rocm() {
   extra_index="${PYTORCH_ROCM_INDEX_URL:-https://download.pytorch.org/whl/rocm6.3}"
 
   # 1) Tooling & base deps for building
-  uv pip install --upgrade pip wheel setuptools setuptools_scm
+  uv pip install --upgrade pip wheel setuptools_scm
   uv pip install numpy cmake ninja packaging typing_extensions
 
   # 2) Install ROCm PyTorch that matches the container ROCm (override via $PYTORCH_ROCM_INDEX_URL if needed)
@@ -65,7 +65,7 @@ build_vllm_from_source_rocm() {
   export PYTORCH_ROCM_ARCH="gfx90a;gfx942"
 
   # 6) Build & install vLLM into this venv
-  uv run --active -- python3 setup.py develop
+  python3 setup.py develop
   cd ..
 }
 

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -61,12 +61,14 @@ build_vllm_from_source_rocm() {
   uv pip install cmake ninja packaging typing_extensions pybind11 wheel
 
   # 2) Install ROCm PyTorch that matches the container ROCm (override via $PYTORCH_ROCM_INDEX_URL if needed)
-  uv pip uninstall torch --yes || true
-  uv pip install --no-cache-dir --pre torch --index-url "${extra_index}"
+  uv pip uninstall torch -- --yes || true
+  uv pip uninstall torchvision -- --yes || true
+  uv pip uninstall torchaudio -- --yes || true
+  uv pip install --no-cache-dir --pre torch torchvision torchaudio --index-url "${extra_index}"
 
   # 3) Install Triton flash attention for ROCm (required by vLLM documentation)
   echo "Installing Triton flash attention for ROCm..."
-  uv pip uninstall triton --yes || true
+  uv pip uninstall triton -- --yes || true
   if ! git clone https://github.com/OpenAI/triton.git; then
     echo "Error: Failed to clone Triton repository"
     exit 1

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -44,8 +44,8 @@ ensure_vllm_installed() {
   echo "Installing vLLM..."
   python3 -m pip install --upgrade pip
   if [[ "$DEVICE_NAME" == "rocm" ]]; then
-    python3 -m pip install "vllm-rocm>=0.9" \
-      --extra-index-url https://download.pytorch.org/whl/rocm6.3
+    # extra_index="${PYTORCH_ROCM_INDEX_URL:-https://download.pytorch.org/whl/rocm6.3}"
+    python3 -m pip install --index-url https://pypi.org/simple vllm-rocm
   else
     python3 -m pip install vllm
   fi
@@ -145,15 +145,15 @@ run_serving_tests() {
       new_test_name=$test_name"_qps_"$qps
       echo " new test name $new_test_name"
 
-      # if vllm bench serve --help >/dev/null 2>&1; then
-      #   client_cmd_prefix="vllm bench serve"
-      # else
-      #   client_cmd_prefix="python -m vllm.benchmarks.serve"
-      # fi
+      if vllm bench serve --help >/dev/null 2>&1; then
+        client_cmd_prefix="vllm bench serve"
+      else
+        client_cmd_prefix="python -m vllm.benchmarks.serve"
+      fi
 
       # pass the tensor parallel size to the client so that it can be displayed
       # on the benchmark dashboard
-      client_command="vllm bench serve \
+      client_command="$client_cmd_prefix \
         --save-result \
         --result-dir $RESULTS_FOLDER \
         --result-filename ${new_test_name}.json \

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -145,9 +145,15 @@ run_serving_tests() {
       new_test_name=$test_name"_qps_"$qps
       echo " new test name $new_test_name"
 
+      if vllm bench serve --help >/dev/null 2>&1; then
+        client_cmd_prefix="vllm bench serve"
+      else
+        client_cmd_prefix="python -m vllm.benchmarks.serve"
+      fi
+
       # pass the tensor parallel size to the client so that it can be displayed
       # on the benchmark dashboard
-      client_command="vllm bench serve \
+      client_command="$client_cmd_prefix \
         --save-result \
         --result-dir $RESULTS_FOLDER \
         --result-filename ${new_test_name}.json \

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -61,14 +61,14 @@ build_vllm_from_source_rocm() {
   uv pip install cmake ninja packaging typing_extensions pybind11 wheel
 
   # 2) Install ROCm PyTorch that matches the container ROCm (override via $PYTORCH_ROCM_INDEX_URL if needed)
-  uv pip uninstall torch -- --yes || true
-  uv pip uninstall torchvision -- --yes || true
-  uv pip uninstall torchaudio -- --yes || true
+  uv pip uninstall --yes torch || true
+  uv pip uninstall --yes torchvision || true
+  uv pip uninstall --yes torchaudio || true
   uv pip install --no-cache-dir --pre torch torchvision torchaudio --index-url "${extra_index}"
 
   # 3) Install Triton flash attention for ROCm (required by vLLM documentation)
   echo "Installing Triton flash attention for ROCm..."
-  uv pip uninstall triton -- --yes || true
+  uv pip uninstall --yes triton || true
   if ! git clone https://github.com/OpenAI/triton.git; then
     echo "Error: Failed to clone Triton repository"
     exit 1
@@ -135,8 +135,8 @@ build_vllm_from_source_rocm() {
   
   # ROCm-specific attention backend settings
   # Try CK flash attention first, fallback to Triton if needed
-  export VLLM_USE_TRITON_FLASH_ATTN=0  # Start with CK flash attention
-  export VLLM_ATTENTION_BACKEND="ROCM_FLASH"
+  # export VLLM_USE_TRITON_FLASH_ATTN=0  # Start with CK flash attention
+  # export VLLM_ATTENTION_BACKEND="ROCM_FLASH"
   
   # Additional ROCm stability settings
   export PYTORCH_HIP_ALLOC_CONF="expandable_segments:True"

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -60,13 +60,13 @@ build_vllm_from_source_rocm() {
   uv pip install --upgrade pip
   uv pip install cmake ninja packaging typing_extensions pybind11 wheel
 
-  # 2) Install ROCm PyTorch that matches the container ROCm (override via $PYTORCH_ROCM_INDEX_URL if needed)
+  # 2) Install ROCm PyTorch that matches the container ROCm
   uv pip uninstall torch || true
   uv pip uninstall torchvision || true
   uv pip uninstall torchaudio || true
   uv pip install --no-cache-dir --pre torch torchvision torchaudio --index-url "${extra_index}"
 
-  # 3) Install Triton flash attention for ROCm (required by vLLM documentation)
+  # 3) Install Triton flash attention for ROCm
   echo "Installing Triton flash attention for ROCm..."
   uv pip uninstall triton || true
   if ! git clone https://github.com/OpenAI/triton.git; then
@@ -87,19 +87,19 @@ build_vllm_from_source_rocm() {
   rm -rf triton
 
   # 4) Install CK flash attention as fallback for ROCm stability
-  echo "Installing CK flash attention for ROCm stability..."
-  git clone https://github.com/ROCm/flash-attention.git
-  cd flash-attention
-  git checkout b7d29fb
-  git submodule update --init
-  # Use detected GPU architecture
-  if ! GPU_ARCHS="$gpu_arch" python3 setup.py install; then
-    echo "Warning: CK flash attention installation failed, continuing with Triton only"
-  else
-    echo "CK flash attention installed successfully"
-  fi
-  cd ..
-  rm -rf flash-attention
+  # echo "Installing CK flash attention for ROCm stability..."
+  # git clone https://github.com/ROCm/flash-attention.git
+  # cd flash-attention
+  # git checkout b7d29fb
+  # git submodule update --init
+  # # Use detected GPU architecture
+  # if ! GPU_ARCHS="$gpu_arch" python3 setup.py install; then
+  #   echo "Warning: CK flash attention installation failed, continuing with Triton only"
+  # else
+  #   echo "CK flash attention installed successfully"
+  # fi
+  # cd ..
+  # rm -rf flash-attention
 
   # 5) Clone vLLM source
   rm -rf vllm
@@ -247,22 +247,7 @@ run_serving_tests() {
     source vllm_client_env/bin/activate
 
     if [[ "${DEVICE_NAME:-}" == "rocm" ]]; then
-      # build_vllm_from_source_rocm
-      uv pip uninstall torch || true
-      uv pip uninstall torchvision || true
-      uv pip uninstall torchaudio || true
-
-      # Install all together from ROCm index
-      uv pip install --no-cache-dir --pre torch torchvision torchaudio --index-url "${extra_index}"
-
-      # Install compatible transformers
-      uv pip install "transformers>=4.45.0,<5.0.0"
-
-      # Install vLLM without dependencies to avoid conflicts
-      uv pip install --no-deps vllm
-
-      # Install remaining compatible dependencies
-      uv pip install tokenizers>=0.19.1 psutil ray>=2.9
+      build_vllm_from_source_rocm
     else
       uv pip install vllm
     fi

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -45,7 +45,7 @@ build_vllm_from_source_rocm() {
 
   # 1) Tooling & base deps for building
   uv pip install --upgrade pip wheel setuptools setuptools_scm
-  uv pip install cmake ninja packaging typing_extensions
+  uv pip install numpy cmake ninja packaging typing_extensions
 
   # 2) Install ROCm PyTorch that matches the container ROCm (override via $PYTORCH_ROCM_INDEX_URL if needed)
   uv pip install --index-url "${extra_index}" --extra-index-url https://pypi.org/simple torch torchvision torchaudio
@@ -65,7 +65,7 @@ build_vllm_from_source_rocm() {
   export PYTORCH_ROCM_ARCH="gfx90a;gfx942"
 
   # 6) Build & install vLLM into this venv
-  uv run --active -- python setup.py develop
+  uv run --active -- python3 setup.py develop
   cd ..
 }
 

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -53,7 +53,7 @@ ensure_vllm_installed() {
   if [[ "$DEVICE_NAME" == "rocm" ]]; then
     echo "Detected ROCm, installing vLLM with bench extras from ROCm wheels"
     # Pin to a version that includes the `bench` CLI;
-    python3 -m pip install "vllm[bench]>=0.9.0" \
+    python3 -m pip install "vllm[bench]>=0.5.2" \
       --extra-index-url https://download.pytorch.org/whl/rocm6.3
   else
     echo "Non-ROCm environment, installing vanilla vLLM (same as before)"

--- a/.github/scripts/run-sglang-performance-benchmarks.sh
+++ b/.github/scripts/run-sglang-performance-benchmarks.sh
@@ -61,14 +61,14 @@ build_vllm_from_source_rocm() {
   uv pip install cmake ninja packaging typing_extensions pybind11 wheel
 
   # 2) Install ROCm PyTorch that matches the container ROCm (override via $PYTORCH_ROCM_INDEX_URL if needed)
-  uv pip uninstall --yes torch || true
-  uv pip uninstall --yes torchvision || true
-  uv pip uninstall --yes torchaudio || true
+  uv pip uninstall torch || true
+  uv pip uninstall torchvision || true
+  uv pip uninstall torchaudio || true
   uv pip install --no-cache-dir --pre torch torchvision torchaudio --index-url "${extra_index}"
 
   # 3) Install Triton flash attention for ROCm (required by vLLM documentation)
   echo "Installing Triton flash attention for ROCm..."
-  uv pip uninstall --yes triton || true
+  uv pip uninstall triton || true
   if ! git clone https://github.com/OpenAI/triton.git; then
     echo "Error: Failed to clone Triton repository"
     exit 1

--- a/.github/workflows/sglang-benchmark.yml
+++ b/.github/workflows/sglang-benchmark.yml
@@ -101,12 +101,12 @@ jobs:
       - name: Get latest tag and its commit hash
         working-directory: sglang-benchmarks/sglang
         run: |
-          latest_tag=$(git for-each-ref --sort=-creatordate --format '%(refname:short)' refs/tags | head -n 1)
-          commit_hash=$(git rev-list -n 1 "$latest_tag")
-          echo "Latest tag: $latest_tag"
-          echo "Commit hash: $commit_hash"
-          echo "latest_tag=$latest_tag" >> $GITHUB_ENV
-          echo "commit_hash=$commit_hash" >> $GITHUB_ENV
+          LATEST_TAG=$(git for-each-ref --sort=-creatordate --format '%(refname:short)' refs/tags | head -n 1)
+          HEAD_SHA=$(git rev-list -n 1 "$LATEST_TAG")
+          echo "Latest tag: $LATEST_TAG"
+          echo "Commit hash: $HEAD_SHA"
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+          echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_ENV
 
       - name: Check if the device is supported
         shell: bash
@@ -186,15 +186,21 @@ jobs:
           set -eux
 
           if [[ "${DEVICE_NAME}" == "cuda" ]]; then
-            DOCKER_IMAGE="lmsysorg/sglang:latest"
+            # Use specific B200 image for B200 devices
+            if [[ "${DEVICE_TYPE}" == *"B200"* ]]; then
+              DOCKER_IMAGE="lmsysorg/sglang:${LATEST_TAG}-cu128-b200"
+            else
+              DOCKER_IMAGE="lmsysorg/sglang:latest"
+            fi
           elif [[ "${DEVICE_NAME}" == "rocm" ]]; then
-            DOCKER_IMAGE="lmsysorg/sglang:v0.5.3rc0-rocm630-mi30x"
+            DOCKER_IMAGE="lmsysorg/sglang:${LATEST_TAG}-rocm630-mi30x"
           else
             echo "SGLang benchmarks require either CUDA or ROCm devices."
             exit 1
           fi
 
           echo "DOCKER_IMAGE=$DOCKER_IMAGE" >> "$GITHUB_ENV"
+          echo "Using Docker image: $DOCKER_IMAGE"
 
       - name: Setup benchmark tests
         env:
@@ -269,9 +275,11 @@ jobs:
           fi
 
           python3 .github/scripts/upload_benchmark_results.py \
-              --repo sglang-benchmarks/sglang \
+              --repo-name sgl-project/sglang \
               --benchmark-name "SGLang benchmark" \
               --benchmark-results "${BENCHMARK_RESULTS}" \
+              --head-sha "${HEAD_SHA}" \
+              --branch-name main \
               --device-name "${DEVICE_NAME}" \
               --device-type "${SANITIZED_DEVICE_TYPE}" \
               --model "${SANITIZED_MODELS}"

--- a/.github/workflows/sglang-benchmark.yml
+++ b/.github/workflows/sglang-benchmark.yml
@@ -98,9 +98,6 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-
       - name: Check if the device is supported
         shell: bash
         run: |
@@ -173,33 +170,21 @@ jobs:
         with:
           registry-type: public
 
-      - name: Install SGLang
-        working-directory: sglang-benchmarks
+      - name: Select SGLang Docker image
         shell: bash
         run: |
           set -eux
-          uv venv sgl_server_env
 
-          # Install SGLang from source
-          uv pip install -p sgl_server_env -e "$(pwd)/sglang/python[all]" boto3 psutil gitpython sentencepiece
+          if [[ "${DEVICE_NAME}" == "cuda" ]]; then
+            DOCKER_IMAGE="lmsysorg/sglang:latest"
+          elif [[ "${DEVICE_NAME}" == "rocm" ]]; then
+            DOCKER_IMAGE="lmsysorg/sglang:v0.5.3rc0-rocm630-mi30x"
+          else
+            echo "SGLang benchmarks require either CUDA or ROCm devices."
+            exit 1
+          fi
 
-          # Verify installations
-          echo "$(pwd)/sgl_server_env/bin" >> $GITHUB_PATH
-
-      - name: Install NVCC #TODO: Use docker image (nvidia/cuda:12.8.1-devel-ubuntu22.04) instead of locally specifying the variables
-        if: env.DEVICE_NAME == 'cuda'
-        shell: bash
-        run: |
-          set -eux
-          sudo apt-get update
-          sudo apt-get install -y wget gnupg
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
-          sudo dpkg -i cuda-keyring_1.1-1_all.deb
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends cuda-toolkit-12-8
-          sudo ln -s /usr/local/cuda-12.8 /usr/local/cuda || true
-          echo "CUDA_HOME=/usr/local/cuda-12.8" >> $GITHUB_ENV
-          echo "/usr/local/cuda-12.8/bin" >> $GITHUB_PATH
+          echo "DOCKER_IMAGE=$DOCKER_IMAGE" >> "$GITHUB_ENV"
 
       - name: Setup benchmark tests
         env:
@@ -222,13 +207,29 @@ jobs:
           find sglang-benchmarks/benchmarks/tests -type f -exec cat {} \; || echo "No test files to display"
 
       - name: Run SGLang benchmark
-        working-directory: sglang-benchmarks/benchmarks
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           SAVE_TO_PYTORCH_BENCHMARK_FORMAT: 1
         run: |
           set -eux
-          bash ../../.github/scripts/run-sglang-performance-benchmarks.sh
+
+          container_name=$(docker run \
+            ${GPU_FLAG:-} \
+            -e HF_TOKEN \
+            -e DEVICE_NAME \
+            -e DEVICE_TYPE \
+            -e SAVE_TO_PYTORCH_BENCHMARK_FORMAT \
+            --ipc=host \
+            --tty \
+            --detach \
+            --security-opt seccomp=unconfined \
+            --shm-size=32g \
+            -v "${GITHUB_WORKSPACE}:/tmp/workspace" \
+            -w /tmp/workspace \
+            "${DOCKER_IMAGE}"
+          )
+
+          docker exec -t "${container_name}" bash -c "cd sglang-benchmarks/benchmarks && bash ../../.github/scripts/run-sglang-performance-benchmarks.sh"
 
       - name: Upload the benchmark results
         if: always()

--- a/.github/workflows/sglang-benchmark.yml
+++ b/.github/workflows/sglang-benchmark.yml
@@ -21,7 +21,7 @@ on:
           A comma-separated list of runners from .github/scripts/generate_vllm_benchmark_matrix.py to run the benchmark (optional, default to run everything)
         required: true
         type: string
-        default: h100
+        default: h100,b200,rocm
   pull_request:
     paths:
       - .github/workflows/sglang-benchmark.yml
@@ -52,7 +52,7 @@ jobs:
         shell: bash
         env:
           MODELS: ${{ inputs.models || '' }}
-          RUNNERS: ${{ inputs.runners || 'h100' }}
+          RUNNERS: ${{ inputs.runners || '' }}
         run: |
           set -eux
 
@@ -97,6 +97,16 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+
+      - name: Get latest tag and its commit hash
+        working-directory: sglang-benchmarks/sglang
+        run: |
+          latest_tag=$(git for-each-ref --sort=-creatordate --format '%(refname:short)' refs/tags | head -n 1)
+          commit_hash=$(git rev-list -n 1 "$latest_tag")
+          echo "Latest tag: $latest_tag"
+          echo "Commit hash: $commit_hash"
+          echo "latest_tag=$latest_tag" >> $GITHUB_ENV
+          echo "commit_hash=$commit_hash" >> $GITHUB_ENV
 
       - name: Check if the device is supported
         shell: bash

--- a/.github/workflows/sglang-benchmark.yml
+++ b/.github/workflows/sglang-benchmark.yml
@@ -188,12 +188,12 @@ jobs:
           if [[ "${DEVICE_NAME}" == "cuda" ]]; then
             # Use specific B200 image for B200 devices
             if [[ "${DEVICE_TYPE}" == *"B200"* ]]; then
-              DOCKER_IMAGE="lmsysorg/sglang:${LATEST_TAG}-cu128-b200"
+              DOCKER_IMAGE="lmsysorg/sglang:v0.5.3rc0-cu128-b200"
             else
               DOCKER_IMAGE="lmsysorg/sglang:latest"
             fi
           elif [[ "${DEVICE_NAME}" == "rocm" ]]; then
-            DOCKER_IMAGE="lmsysorg/sglang:${LATEST_TAG}-rocm630-mi30x"
+            DOCKER_IMAGE="lmsysorg/sglang:v0.5.3rc0-rocm630-mi30x"
           else
             echo "SGLang benchmarks require either CUDA or ROCm devices."
             exit 1

--- a/.github/workflows/sglang-benchmark.yml
+++ b/.github/workflows/sglang-benchmark.yml
@@ -247,6 +247,16 @@ jobs:
 
           docker exec -t "${container_name}" bash -c "cd sglang-benchmarks/benchmarks && bash ../../.github/scripts/run-sglang-performance-benchmarks.sh"
 
+      - name: Authenticate with AWS
+        # AWS CUDA runners already have access to the bucket via its runner IAM role
+        if: env.DEVICE_NAME == 'rocm' || contains(env.DEVICE_TYPE, 'B200')
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_upload-benchmark-results
+          # The max duration enforced by the server side
+          role-duration-seconds: 18000
+          aws-region: us-east-1
+
       - name: Upload the benchmark results
         if: always()
         env:

--- a/.github/workflows/sglang-benchmark.yml
+++ b/.github/workflows/sglang-benchmark.yml
@@ -279,7 +279,7 @@ jobs:
               --benchmark-name "SGLang benchmark" \
               --benchmark-results "${BENCHMARK_RESULTS}" \
               --head-sha "${HEAD_SHA}" \
-              --branch-name main \
+              --head-branch main \
               --device-name "${DEVICE_NAME}" \
               --device-type "${SANITIZED_DEVICE_TYPE}" \
               --model "${SANITIZED_MODELS}"

--- a/.github/workflows/sglang-benchmark.yml
+++ b/.github/workflows/sglang-benchmark.yml
@@ -98,11 +98,6 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
-      - name: Get commit hash for Docker image selection
-        working-directory: sglang-benchmarks/sglang
-        run: |
-          # We'll get the commit hash after determining the available Docker image
-          echo "HEAD_SHA=placeholder" >> $GITHUB_ENV
 
       - name: Check if the device is supported
         shell: bash

--- a/.github/workflows/sglang-benchmark.yml
+++ b/.github/workflows/sglang-benchmark.yml
@@ -98,15 +98,11 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
-      - name: Get latest tag and its commit hash
+      - name: Get commit hash for Docker image selection
         working-directory: sglang-benchmarks/sglang
         run: |
-          LATEST_TAG=$(git for-each-ref --sort=-creatordate --format '%(refname:short)' refs/tags | head -n 1)
-          HEAD_SHA=$(git rev-list -n 1 "$LATEST_TAG")
-          echo "Latest tag: $LATEST_TAG"
-          echo "Commit hash: $HEAD_SHA"
-          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
-          echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_ENV
+          # We'll get the commit hash after determining the available Docker image
+          echo "HEAD_SHA=placeholder" >> $GITHUB_ENV
 
       - name: Check if the device is supported
         shell: bash
@@ -181,26 +177,52 @@ jobs:
           registry-type: public
 
       - name: Select SGLang Docker image
+        working-directory: sglang-benchmarks/sglang
         shell: bash
         run: |
           set -eux
 
+          # Determine image suffix based on device
           if [[ "${DEVICE_NAME}" == "cuda" ]]; then
-            # Use specific B200 image for B200 devices
             if [[ "${DEVICE_TYPE}" == *"B200"* ]]; then
-              DOCKER_IMAGE="lmsysorg/sglang:v0.5.3rc0-cu128-b200"
+              IMAGE_SUFFIX="-cu128-b200"
             else
-              DOCKER_IMAGE="lmsysorg/sglang:latest"
+              IMAGE_SUFFIX=""
             fi
           elif [[ "${DEVICE_NAME}" == "rocm" ]]; then
-            DOCKER_IMAGE="lmsysorg/sglang:v0.5.3rc0-rocm630-mi30x"
+            IMAGE_SUFFIX="-rocm630-mi30x"
           else
             echo "SGLang benchmarks require either CUDA or ROCm devices."
             exit 1
           fi
 
+          # Find the newest tag with available Docker image
+          SELECTED_TAG=""
+          for tag in $(git for-each-ref --sort=-creatordate --format '%(refname:short)' refs/tags); do
+            candidate_image="lmsysorg/sglang:${tag}${IMAGE_SUFFIX}"
+            echo "Checking: $candidate_image"
+            
+            if docker manifest inspect "$candidate_image" >/dev/null 2>&1; then
+              SELECTED_TAG="$tag"
+              DOCKER_IMAGE="$candidate_image"
+              HEAD_SHA=$(git rev-list -n 1 "$tag")
+              echo "Found available image: $candidate_image"
+              break
+            fi
+          done
+          
+          # Fallback to latest if no tagged version found
+          if [[ -z "$SELECTED_TAG" ]]; then
+            echo "No tagged images found, using latest"
+            DOCKER_IMAGE="lmsysorg/sglang:latest${IMAGE_SUFFIX}"
+            HEAD_SHA=$(git rev-parse HEAD)
+            SELECTED_TAG="latest"
+          fi
+
           echo "DOCKER_IMAGE=$DOCKER_IMAGE" >> "$GITHUB_ENV"
-          echo "Using Docker image: $DOCKER_IMAGE"
+          echo "HEAD_SHA=$HEAD_SHA" >> "$GITHUB_ENV"
+          echo "LATEST_TAG=$SELECTED_TAG" >> "$GITHUB_ENV"
+          echo "Using: $DOCKER_IMAGE (tag: $SELECTED_TAG)"
 
       - name: Setup benchmark tests
         env:

--- a/sglang-benchmarks/benchmarks/cuda/serving-tests.json
+++ b/sglang-benchmarks/benchmarks/cuda/serving-tests.json
@@ -134,5 +134,59 @@
             "random_input_len": 5250,
             "random_output_len": 8250
         }
+    },
+    {
+        "test_name": "serving_gpt_oss_120b_tp4_random_in5k_out8k",
+        "qps_list": [1, 4, 16, "inf"],
+        "server_parameters": {
+            "model": "openai/gpt-oss-120b",
+            "tensor_parallel_size": 4,
+            "load_format": "dummy",
+            "context_length": 16384
+        },
+        "client_parameters": {
+            "model": "openai/gpt-oss-120b",
+            "backend": "vllm",
+            "dataset_name": "random",
+            "num_prompts": 200,
+            "random_input_len": 5250,
+            "random_output_len": 8250
+        }
+    },
+    {
+        "test_name": "serving_deepseek_v3_tp8_random_in5k_out8k",
+        "qps_list": [1, 4, 16, "inf"],
+        "server_parameters": {
+            "model": "deepseek-ai/DeepSeek-V3.1",
+            "tensor_parallel_size": 8,
+            "load_format": "dummy",
+            "context_length": 16384
+        },
+        "client_parameters": {
+            "model": "deepseek-ai/DeepSeek-V3.1",
+            "backend": "vllm",
+            "dataset_name": "random",
+            "num_prompts": 200,
+            "random_input_len": 5250,
+            "random_output_len": 8250
+        }
+    },
+    {
+        "test_name": "serving_deepseek_r1_tp8_random_in5k_out8k",
+        "qps_list": [1, 4, 16, "inf"],
+        "server_parameters": {
+            "model": "deepseek-ai/DeepSeek-R1",
+            "tensor_parallel_size": 8,
+            "load_format": "dummy",
+            "context_length": 16384
+        },
+        "client_parameters": {
+            "model": "deepseek-ai/DeepSeek-R1",
+            "backend": "vllm",
+            "dataset_name": "random",
+            "num_prompts": 200,
+            "random_input_len": 5250,
+            "random_output_len": 8250
+        }
     }
 ]

--- a/sglang-benchmarks/benchmarks/cuda/serving-tests.json
+++ b/sglang-benchmarks/benchmarks/cuda/serving-tests.json
@@ -5,9 +5,6 @@
         "server_parameters": {
             "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
             "tensor_parallel_size": 1,
-            "swap_space": 16,
-            "disable_log_stats": "",
-            "disable_log_requests": "",
             "load_format": "dummy"
         },
         "client_parameters": {
@@ -24,9 +21,6 @@
         "server_parameters": {
             "model": "google/gemma-3-27b-it",
             "tensor_parallel_size": 8,
-            "swap_space": 16,
-            "disable_log_stats": "",
-            "disable_log_requests": "",
             "load_format": "dummy",
             "context_length": 8192
         },
@@ -45,9 +39,6 @@
         "server_parameters": {
             "model": "google/gemma-3-4b-it",
             "tensor_parallel_size": 1,
-            "swap_space": 16,
-            "disable_log_stats": "",
-            "disable_log_requests": "",
             "load_format": "dummy",
             "context_length": 8192
         },
@@ -66,9 +57,6 @@
         "server_parameters": {
             "model": "facebook/opt-125m",
             "tensor_parallel_size": 1,
-            "swap_space": 16,
-            "disable_log_stats": "",
-            "disable_log_requests": "",
             "load_format": "dummy",
             "context_length": 2048
         },
@@ -86,9 +74,6 @@
         "server_parameters": {
             "model": "facebook/opt-125m",
             "tensor_parallel_size": 1,
-            "swap_space": 16,
-            "disable_log_stats": "",
-            "disable_log_requests": "",
             "load_format": "dummy",
             "context_length": 2048
         },

--- a/sglang-benchmarks/benchmarks/rocm/serving-tests.json
+++ b/sglang-benchmarks/benchmarks/rocm/serving-tests.json
@@ -106,7 +106,7 @@
         "test_name": "serving_gpt_oss_20b_tp1_random_in5k_out8k",
         "qps_list": [1, 4, 16, "inf"],
         "server_parameters": {
-            "model": "openai/gpt-oss-20b",
+            "model": "lmsys/gpt-oss-20b-bf16",
             "tensor_parallel_size": 1,
             "load_format": "dummy",
             "context_length": 16384
@@ -124,7 +124,7 @@
         "test_name": "serving_gpt_oss_120b_tp4_random_in5k_out8k",
         "qps_list": [1, 4, 16, "inf"],
         "server_parameters": {
-            "model": "openai/gpt-oss-120b",
+            "model": "lmsys/gpt-oss-120b-bf16",
             "tensor_parallel_size": 4,
             "load_format": "dummy",
             "context_length": 16384
@@ -145,7 +145,8 @@
             "model": "deepseek-ai/DeepSeek-V3.1",
             "tensor_parallel_size": 8,
             "load_format": "dummy",
-            "context_length": 16384
+            "context_length": 16384,
+            "dtype": "float16"
         },
         "client_parameters": {
             "model": "deepseek-ai/DeepSeek-V3.1",
@@ -163,7 +164,8 @@
             "model": "deepseek-ai/DeepSeek-R1",
             "tensor_parallel_size": 8,
             "load_format": "dummy",
-            "context_length": 16384
+            "context_length": 16384,
+            "dtype": "float16"
         },
         "client_parameters": {
             "model": "deepseek-ai/DeepSeek-R1",

--- a/sglang-benchmarks/benchmarks/rocm/serving-tests.json
+++ b/sglang-benchmarks/benchmarks/rocm/serving-tests.json
@@ -5,9 +5,6 @@
         "server_parameters": {
             "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
             "tensor_parallel_size": 1,
-            "swap_space": 16,
-            "disable_log_stats": "",
-            "disable_log_requests": "",
             "load_format": "dummy"
         },
         "client_parameters": {
@@ -24,9 +21,6 @@
         "server_parameters": {
             "model": "google/gemma-3-27b-it",
             "tensor_parallel_size": 8,
-            "swap_space": 16,
-            "disable_log_stats": "",
-            "disable_log_requests": "",
             "load_format": "dummy",
             "context_length": 8192
         },
@@ -45,9 +39,6 @@
         "server_parameters": {
             "model": "google/gemma-3-4b-it",
             "tensor_parallel_size": 1,
-            "swap_space": 16,
-            "disable_log_stats": "",
-            "disable_log_requests": "",
             "load_format": "dummy",
             "context_length": 8192
         },
@@ -66,9 +57,6 @@
         "server_parameters": {
             "model": "facebook/opt-125m",
             "tensor_parallel_size": 1,
-            "swap_space": 16,
-            "disable_log_stats": "",
-            "disable_log_requests": "",
             "load_format": "dummy",
             "context_length": 2048
         },
@@ -86,9 +74,6 @@
         "server_parameters": {
             "model": "facebook/opt-125m",
             "tensor_parallel_size": 1,
-            "swap_space": 16,
-            "disable_log_stats": "",
-            "disable_log_requests": "",
             "load_format": "dummy",
             "context_length": 2048
         },
@@ -99,6 +84,22 @@
             "num_prompts": 200,
             "random_input_len": 750,
             "random_output_len": 75
+        }
+    },
+    {
+        "test_name": "serving_llama70B_tp4_sharegpt",
+        "qps_list": [1, 4, 16, "inf"],
+        "server_parameters": {
+            "model": "meta-llama/Meta-Llama-3.1-70B-Instruct",
+            "tensor_parallel_size": 4,
+            "load_format": "dummy"
+        },
+        "client_parameters": {
+            "model": "meta-llama/Meta-Llama-3.1-70B-Instruct",
+            "backend": "vllm",
+            "dataset_name": "sharegpt",
+            "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200
         }
     }
 ]

--- a/sglang-benchmarks/benchmarks/rocm/serving-tests.json
+++ b/sglang-benchmarks/benchmarks/rocm/serving-tests.json
@@ -101,5 +101,77 @@
             "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",
             "num_prompts": 200
         }
+    },
+    {
+        "test_name": "serving_gpt_oss_20b_tp1_random_in5k_out8k",
+        "qps_list": [1, 4, 16, "inf"],
+        "server_parameters": {
+            "model": "openai/gpt-oss-20b",
+            "tensor_parallel_size": 1,
+            "load_format": "dummy",
+            "context_length": 16384
+        },
+        "client_parameters": {
+            "model": "openai/gpt-oss-20b",
+            "backend": "vllm",
+            "dataset_name": "random",
+            "num_prompts": 200,
+            "random_input_len": 5250,
+            "random_output_len": 8250
+        }
+    },
+    {
+        "test_name": "serving_gpt_oss_120b_tp4_random_in5k_out8k",
+        "qps_list": [1, 4, 16, "inf"],
+        "server_parameters": {
+            "model": "openai/gpt-oss-120b",
+            "tensor_parallel_size": 4,
+            "load_format": "dummy",
+            "context_length": 16384
+        },
+        "client_parameters": {
+            "model": "openai/gpt-oss-120b",
+            "backend": "vllm",
+            "dataset_name": "random",
+            "num_prompts": 200,
+            "random_input_len": 5250,
+            "random_output_len": 8250
+        }
+    },
+    {
+        "test_name": "serving_deepseek_v3_tp8_random_in5k_out8k",
+        "qps_list": [1, 4, 16, "inf"],
+        "server_parameters": {
+            "model": "deepseek-ai/DeepSeek-V3.1",
+            "tensor_parallel_size": 8,
+            "load_format": "dummy",
+            "context_length": 16384
+        },
+        "client_parameters": {
+            "model": "deepseek-ai/DeepSeek-V3.1",
+            "backend": "vllm",
+            "dataset_name": "random",
+            "num_prompts": 200,
+            "random_input_len": 5250,
+            "random_output_len": 8250
+        }
+    },
+    {
+        "test_name": "serving_deepseek_r1_tp8_random_in5k_out8k",
+        "qps_list": [1, 4, 16, "inf"],
+        "server_parameters": {
+            "model": "deepseek-ai/DeepSeek-R1",
+            "tensor_parallel_size": 8,
+            "load_format": "dummy",
+            "context_length": 16384
+        },
+        "client_parameters": {
+            "model": "deepseek-ai/DeepSeek-R1",
+            "backend": "vllm",
+            "dataset_name": "random",
+            "num_prompts": 200,
+            "random_input_len": 5250,
+            "random_output_len": 8250
+        }
     }
 ]

--- a/sglang-benchmarks/benchmarks/rocm/serving-tests.json
+++ b/sglang-benchmarks/benchmarks/rocm/serving-tests.json
@@ -141,45 +141,5 @@
             "random_input_len": 5250,
             "random_output_len": 8250
         }
-    },
-    {
-        "test_name": "serving_deepseek_v3_tp8_random_in5k_out8k",
-        "qps_list": [1, 4, 16, "inf"],
-        "server_parameters": {
-            "model": "deepseek-ai/DeepSeek-V3.1",
-            "tensor_parallel_size": 8,
-            "load_format": "dummy",
-            "context_length": 16384,
-            "disable_radix_cache": "",
-            "trust_remote_code": ""
-        },
-        "client_parameters": {
-            "model": "deepseek-ai/DeepSeek-V3.1",
-            "backend": "vllm",
-            "dataset_name": "random",
-            "num_prompts": 200,
-            "random_input_len": 5250,
-            "random_output_len": 8250
-        }
-    },
-    {
-        "test_name": "serving_deepseek_r1_tp8_random_in5k_out8k",
-        "qps_list": [1, 4, 16, "inf"],
-        "server_parameters": {
-            "model": "deepseek-ai/DeepSeek-R1",
-            "tensor_parallel_size": 8,
-            "load_format": "dummy",
-            "context_length": 16384,
-            "disable_radix_cache": "",
-            "trust_remote_code": ""
-        },
-        "client_parameters": {
-            "model": "deepseek-ai/DeepSeek-R1",
-            "backend": "vllm",
-            "dataset_name": "random",
-            "num_prompts": 200,
-            "random_input_len": 5250,
-            "random_output_len": 8250
-        }
     }
 ]

--- a/sglang-benchmarks/benchmarks/rocm/serving-tests.json
+++ b/sglang-benchmarks/benchmarks/rocm/serving-tests.json
@@ -109,7 +109,9 @@
             "model": "lmsys/gpt-oss-20b-bf16",
             "tensor_parallel_size": 1,
             "load_format": "dummy",
-            "context_length": 16384
+            "context_length": 16384,
+            "attention_backend": "triton",
+            "trust_remote_code": ""
         },
         "client_parameters": {
             "model": "openai/gpt-oss-20b",
@@ -127,7 +129,9 @@
             "model": "lmsys/gpt-oss-120b-bf16",
             "tensor_parallel_size": 4,
             "load_format": "dummy",
-            "context_length": 16384
+            "context_length": 16384,
+            "attention_backend": "triton",
+            "trust_remote_code": ""
         },
         "client_parameters": {
             "model": "openai/gpt-oss-120b",
@@ -146,7 +150,8 @@
             "tensor_parallel_size": 8,
             "load_format": "dummy",
             "context_length": 16384,
-            "dtype": "float16"
+            "disable_radix_cache": "",
+            "trust_remote_code": ""
         },
         "client_parameters": {
             "model": "deepseek-ai/DeepSeek-V3.1",
@@ -165,7 +170,8 @@
             "tensor_parallel_size": 8,
             "load_format": "dummy",
             "context_length": 16384,
-            "dtype": "float16"
+            "disable_radix_cache": "",
+            "trust_remote_code": ""
         },
         "client_parameters": {
             "model": "deepseek-ai/DeepSeek-R1",

--- a/sglang-benchmarks/benchmarks/rocm/serving-tests.json
+++ b/sglang-benchmarks/benchmarks/rocm/serving-tests.json
@@ -100,39 +100,5 @@
             "random_input_len": 750,
             "random_output_len": 75
         }
-    },
-    {
-        "test_name": "serving_llama70B_tp4_sharegpt",
-        "qps_list": [1, 4, 16, "inf"],
-        "server_parameters": {
-            "model": "meta-llama/Meta-Llama-3.1-70B-Instruct",
-            "tensor_parallel_size": 4,
-            "load_format": "dummy"
-        },
-        "client_parameters": {
-            "model": "meta-llama/Meta-Llama-3.1-70B-Instruct",
-            "backend": "vllm",
-            "dataset_name": "sharegpt",
-            "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json",
-            "num_prompts": 200
-        }
-    },
-    {
-        "test_name": "serving_gpt_oss_20b_tp1_random_in5k_out8k",
-        "qps_list": [1, 4, 16, "inf"],
-        "server_parameters": {
-            "model": "openai/gpt-oss-20b",
-            "tensor_parallel_size": 1,
-            "load_format": "dummy",
-            "context_length": 16384
-        },
-        "client_parameters": {
-            "model": "openai/gpt-oss-20b",
-            "backend": "vllm",
-            "dataset_name": "random",
-            "num_prompts": 200,
-            "random_input_len": 5250,
-            "random_output_len": 8250
-        }
     }
 ]


### PR DESCRIPTION
## Changes

- Adding support for bigger models for the NVIDIA GPUs for SGLang Benchmarking:  `Llama-3.1-70B, Gpt-oss-20b, Gpt-oss-120b, DeepSeek-V3.1, DeepSeek-R1`
- Integrating support for running SGLang benchmarking on the AMD GPUs. Currently, we are adding these models: `Llama-3.1-8B, Llama-3.1-70B, Facebook/opt-125m, Gpt-oss-20b, Gpt-oss-120b`
- Refactoring the benchmarking workflow to use pre-built docker images for both NVIDIA and AMD GPUs.
- Running the benchmarking on the latest tags released by SGLang.

## Testing

- Verified that the Github Actions are running fine for all the models on both devices: [link](https://github.com/pytorch/pytorch-integration-testing/actions/runs/17869977775)
- The benchmarking results are visible on the HUD Dashboard as well: [Dashboard](https://hud.pytorch.org/benchmark/llms?repoName=sgl-project%2Fsglang)

TODO (for future):
1. We might have to add support for Deepseek models, and debug the root-cause of Gemma models.