### PR TITLE
[Profiling] Upload vLLM Profiling results to AWS S3

### DIFF
--- a/.github/scripts/run_vllm_profiling.sh
+++ b/.github/scripts/run_vllm_profiling.sh
@@ -59,6 +59,12 @@ cleanup_server() {
 run_profiling_tests() {
     # run profiling tests using JSON configuration
     local profiling_test_file="$1"
+    local base_profiler_dir="${VLLM_TORCH_PROFILER_DIR:-}"
+
+    if [[ -z "${base_profiler_dir}" ]]; then
+        echo "Error: VLLM_TORCH_PROFILER_DIR is not set."
+        exit 1
+    fi
 
     if [[ ! -f "$profiling_test_file" ]]; then
         echo "Error: Profiling test file $profiling_test_file not found!"
@@ -92,17 +98,27 @@ run_profiling_tests() {
         # Clean up any existing processes first
         kill_gpu_processes
 
+        # Create a profiling sub-directory for each test case to isolate the
+        # generated traces (e.g. using the model name hierarchy)
+        local sanitized_test_name="${TEST_NAME// /_}"
+        local test_name_directory="${base_profiler_dir}/${sanitized_test_name}"
+        mkdir -p "${test_name_directory}"
+        chmod 755 "${test_name_directory}"
+
+        # Override the profiler output directory for this test only
+        export VLLM_TORCH_PROFILER_DIR="${test_name_directory}"
+
         # Run the profiling test
         if start_vllm_server "$server_args"; then
             run_profiling "$client_args"
             cleanup_server
 
             # Debug: Check if profiling files were created
-            echo "DEBUG: Checking profiling directory: ${VLLM_TORCH_PROFILER_DIR}"
-            if [ -d "${VLLM_TORCH_PROFILER_DIR}" ]; then
+            echo "DEBUG: Checking profiling directory: $test_name_directory"
+            if [ -d "$test_name_directory" ]; then
                 echo "DEBUG: Profiling directory exists for test $TEST_NAME"
-                ls -la "${VLLM_TORCH_PROFILER_DIR}" || echo "DEBUG: Directory is empty or inaccessible"
-                find "${VLLM_TORCH_PROFILER_DIR}" -type f 2>/dev/null | head -10 | while read file; do
+                ls -la "$test_name_directory" || echo "DEBUG: Directory is empty or inaccessible"
+                find "$test_name_directory" -type f 2>/dev/null | head -10 | while read file; do
                     echo "DEBUG: Found profiling file: ${file}"
                 done
             else
@@ -115,6 +131,9 @@ run_profiling_tests() {
             continue
         fi
     done
+
+    # Ensure the profiler directory is restored after processing all tests
+    export VLLM_TORCH_PROFILER_DIR="${base_profiler_dir}"
 }
 
 main() {

--- a/.github/scripts/run_vllm_profiling.sh
+++ b/.github/scripts/run_vllm_profiling.sh
@@ -120,6 +120,7 @@ run_profiling_tests() {
                 ls -la "$test_name_directory" || echo "DEBUG: Directory is empty or inaccessible"
                 find "$test_name_directory" -type f 2>/dev/null | head -10 | while read file; do
                     echo "DEBUG: Found profiling file: ${file}"
+                    rename_profiling_file "$file" "vllm"
                 done
             else
                 echo "DEBUG: Profiling directory does not exist for test $TEST_NAME!"

--- a/.github/scripts/utilities.sh
+++ b/.github/scripts/utilities.sh
@@ -133,3 +133,46 @@ check_hf_token() {
         echo "HF_TOKEN is set and valid."
     fi
 }
+
+rename_profiling_file() {
+    # Rename profiling files to standardized format
+    # $1: file path to rename
+    # $2: prefix name (e.g., "vllm", "sglang")
+    local file="$1"
+    local prefix_name="$2"
+
+    # Process .pt.trace.json.gz files
+    if [[ "$file" == *.pt.trace.json.gz ]]; then
+        local dir_path=$(dirname "$file")
+        local basename_file=$(basename "$file")
+
+        # Determine new filename based on content
+        local new_filename
+        if [[ "$basename_file" == *".async_llm."* ]]; then
+            new_filename="${prefix_name}.async_llm.pt.trace.json.gz"
+        else
+            new_filename="${prefix_name}.pt.trace.json.gz"
+        fi
+
+        local new_filepath="${dir_path}/${new_filename}"
+
+        # Only rename if the new filename is different
+        if [[ "$file" != "$new_filepath" ]]; then
+            echo "DEBUG: Renaming ${file} to ${new_filepath}"
+            mv "$file" "$new_filepath"
+            if [[ $? -eq 0 ]]; then
+                echo "DEBUG: Successfully renamed to ${new_filepath}"
+                return 0
+            else
+                echo "DEBUG: Failed to rename ${file}"
+                return 1
+            fi
+        else
+            echo "DEBUG: File ${file} already has correct name"
+            return 0
+        fi
+    else
+        echo "DEBUG: Skipping non-profiling file: ${file}"
+        return 0
+    fi
+}

--- a/.github/workflows/vllm-profiling.yml
+++ b/.github/workflows/vllm-profiling.yml
@@ -217,7 +217,7 @@ jobs:
       - name: Prepare S3 upload metadata
         id: prepare_s3_upload
         env:
-          REPOSITORY: ${{ github.repository }}
+          REPOSITORY: vllm-project/vllm
         run: |
           set -eux
 

--- a/.github/workflows/vllm-profiling.yml
+++ b/.github/workflows/vllm-profiling.yml
@@ -214,6 +214,25 @@ jobs:
           )
           docker exec -t "${container_name}" bash -c "cd vllm-profiling && bash ../.github/scripts/run_vllm_profiling.sh"
 
+      - name: Prepare S3 upload metadata
+        id: prepare_s3_upload
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -eux
+
+          UPLOAD_DATE=$(date -u +"%Y-%m-%d")
+          echo "upload-date=${UPLOAD_DATE}" >> "${GITHUB_OUTPUT}"
+          echo "s3-prefix=${REPOSITORY}/${UPLOAD_DATE}/${HEAD_SHA}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload profiling results to S3
+        uses: seemethere/upload-artifact-s3@v5
+        retention-days: 180
+        with:
+          s3-prefix: ${{ steps.prepare_s3_upload.outputs.s3-prefix }}
+          path: vllm-profiling/profiling-results
+          if-no-files-found: warn
+
       - uses: actions/upload-artifact@v4
         with:
           name: profiling-results--${{ env.DEVICE_TYPE }}

--- a/.github/workflows/vllm-profiling.yml
+++ b/.github/workflows/vllm-profiling.yml
@@ -223,7 +223,7 @@ jobs:
 
           UPLOAD_DATE=$(date -u +"%Y-%m-%d")
           echo "upload-date=${UPLOAD_DATE}" >> "${GITHUB_OUTPUT}"
-          echo "s3-prefix=${REPOSITORY}/${UPLOAD_DATE}/${HEAD_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "s3-prefix=${UPLOAD_DATE}/${REPOSITORY}/${HEAD_SHA}/${GITHUB_RUN_ID}/${GITHUB_JOB}" >> "${GITHUB_OUTPUT}"
 
       - name: Upload profiling results to S3
         uses: seemethere/upload-artifact-s3@v5

--- a/.github/workflows/vllm-profiling.yml
+++ b/.github/workflows/vllm-profiling.yml
@@ -227,9 +227,9 @@ jobs:
 
       - name: Upload profiling results to S3
         uses: seemethere/upload-artifact-s3@v5
-        retention-days: 180
         with:
           s3-prefix: ${{ steps.prepare_s3_upload.outputs.s3-prefix }}
+          retention-days: 180
           path: vllm-profiling/profiling-results
           if-no-files-found: warn
 

--- a/vllm-profiling/cuda/profiling-tests.json
+++ b/vllm-profiling/cuda/profiling-tests.json
@@ -1,6 +1,6 @@
 [
     {
-        "test_name": "profiling_opt_125m_tp1_random",
+        "test_name": "facebook_opt_125m_tp1_random",
         "server_parameters": {
             "model": "facebook/opt-125m",
             "swap_space": 16,


### PR DESCRIPTION
This PR includes the following changes:
- Added a new Github step to upload the vllm profiling results to AWS S3 bucket.
- Refactoring the way results will be uploaded to S3. We are adding an extra folder name (model_name) to the base S3 prefix, so that it can be easy for us to identify the different profiling results of different models.
- The S3 path prefix is as follows: `<date>/<repository>/<commit_sha>/<github_workflow_id>/<github_job_id>`

**Testing**
<img width="945" height="373" alt="Screenshot 2025-09-16 at 11 23 55 PM" src="https://github.com/user-attachments/assets/52b7f4b0-2a2a-4780-a477-4eae25770439" />


Github Action: [link](https://github.com/pytorch/pytorch-integration-testing/actions/runs/17788403923/job/50560173197)

Download link for Profiling traces: 
- https://gha-artifacts.s3.us-east-1.amazonaws.com/2025-09-17/vllm-project/vllm/ca2d1925ef5ad309061c2d5dd9a1e409c5ca28ee/17788403923/profiling/facebook_opt_125m_tp1_random/vllm.async_llm.pt.trace.json.gz
- https://gha-artifacts.s3.us-east-1.amazonaws.com/2025-09-17/vllm-project/vllm/ca2d1925ef5ad309061c2d5dd9a1e409c5ca28ee/17788403923/profiling/facebook_opt_125m_tp1_random/vllm.pt.trace.json.gz
