### PR TITLE
[ez] Run latency and throughput benchmark for Qwen3 and Gemma3

### DIFF
--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -2,8 +2,8 @@ name: vLLM Benchmark
 
 on:
   schedule:
-    # Run every 6 hours
-    - cron: '0 */6 * * *'
+    # Run every 12 hours
+    - cron: '0 */12 * * *'
   workflow_dispatch:
     inputs:
       vllm_branch:

--- a/vllm-benchmarks/benchmarks/cuda/latency-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/latency-tests.json
@@ -105,5 +105,27 @@
             "num_iters": 15,
             "max_model_len": 8192
         }
+    },
+    {
+        "test_name": "latency_gemma_3_27b_it_tp8",
+        "parameters": {
+            "model": "google/gemma-3-27b-it",
+            "tensor_parallel_size": 8,
+            "load_format": "dummy",
+            "num_iters_warmup": 5,
+            "num_iters": 15,
+            "max_model_len": 8192
+        }
+    },
+    {
+        "test_name": "latency_qwen3_30b_a3b_tp8",
+        "parameters": {
+            "model": "Qwen/Qwen3-30B-A3B",
+            "tensor_parallel_size": 8,
+            "load_format": "dummy",
+            "num_iters_warmup": 5,
+            "num_iters": 15,
+            "max_model_len": 8192
+        }
     }
 ]

--- a/vllm-benchmarks/benchmarks/cuda/throughput-tests.json
+++ b/vllm-benchmarks/benchmarks/cuda/throughput-tests.json
@@ -115,5 +115,29 @@
             "backend": "vllm",
             "max_model_len": 8192
         }
+    },
+    {
+        "test_name": "throughput_gemma_3_27b_it_tp8",
+        "parameters": {
+            "model": "google/gemma-3-27b-it",
+            "tensor_parallel_size": 8,
+            "load_format": "dummy",
+            "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200,
+            "backend": "vllm",
+            "max_model_len": 8192
+        }
+    },
+    {
+        "test_name": "throughput_qwen3_30b_a3b_tp8",
+        "parameters": {
+            "model": "Qwen/Qwen3-30B-A3B",
+            "tensor_parallel_size": 8,
+            "load_format": "dummy",
+            "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200,
+            "backend": "vllm",
+            "max_model_len": 8192
+        }
     }
 ]


### PR DESCRIPTION
They should have been added by https://github.com/pytorch/pytorch-integration-testing/pull/42, but weren't.  Also I reduce the frequency to 12 hours now as there is no ask to run it every 6 hour and I want to free up some capacity for lm-eval