### PR TITLE
Downgrade torchao to 0.15.0

### DIFF
--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -345,7 +345,7 @@ jobs:
           )
           if [[ "${DEVICE_NAME}" == "cuda" ]]; then
             docker exec -t "${container_name}" bash -c "
-              pip install torchao==0.17.0.dev20260305+cu130 fbgemm_gpu_genai==2026.3.4+cu130 --extra-index-url https://download.pytorch.org/whl/nightly
+              pip install torchao==0.15.0 fbgemm_gpu_genai==1.5.0 --extra-index-url https://download.pytorch.org/whl/cu130
 
               # A quick mitigation for https://github.com/vllm-project/vllm/issues/32373
               rm /etc/ld.so.conf.d/cuda-compat.conf || true

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -295,7 +295,6 @@ jobs:
           SCCACHE_REGION: us-east-1
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HOME: /mnt/hf_cache
-          TRANSFORMERS_OFFLINE: 1
           DOCKER_IMAGE: ${{ env.DOCKER_IMAGE_PREFIX }}:${{ env.HEAD_SHA }}${{ env.DOCKER_IMAGE_SUFFIX }}
           # vLLM-related environment variables
           ENGINE_VERSION: v1
@@ -314,9 +313,6 @@ jobs:
             export HF_HOME="${RUNNER_TEMP}/hf_cache"
             mkdir -p "${HF_HOME}"
 
-            # When there is no cache directory, e.g. benchmark, the job has no
-            # way but to reach out to HF if needed
-            export TRANSFORMERS_OFFLINE=0
           fi
 
           container_name=$(docker run \
@@ -328,7 +324,6 @@ jobs:
             -e DEVICE_TYPE \
             -e HF_TOKEN \
             -e HF_HOME \
-            -e TRANSFORMERS_OFFLINE \
             -e ENGINE_VERSION \
             -e SAVE_TO_PYTORCH_BENCHMARK_FORMAT \
             -e ON_CPU="${ON_CPU}" \

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -347,7 +347,7 @@ jobs:
           )
           if [[ "${DEVICE_NAME}" == "cuda" ]]; then
             docker exec -t "${container_name}" bash -c "
-              pip install torchao==0.15.0 fbgemm_gpu_genai==1.5.0 --extra-index-url https://download.pytorch.org/whl/cu130
+              pip install torchao==0.15.0 fbgemm-gpu-genai==1.5.0 --extra-index-url https://download.pytorch.org/whl/cu130
 
               # A quick mitigation for https://github.com/vllm-project/vllm/issues/32373
               rm /etc/ld.so.conf.d/cuda-compat.conf || true

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -295,7 +295,8 @@ jobs:
           SCCACHE_REGION: us-east-1
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HOME: /mnt/hf_cache
-          TRANSFORMERS_OFFLINE: 1
+          # TODO: Set to 0 for testing, revert before landing
+          TRANSFORMERS_OFFLINE: 0
           DOCKER_IMAGE: ${{ env.DOCKER_IMAGE_PREFIX }}:${{ env.HEAD_SHA }}${{ env.DOCKER_IMAGE_SUFFIX }}
           # vLLM-related environment variables
           ENGINE_VERSION: v1

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -344,7 +344,7 @@ jobs:
           )
           if [[ "${DEVICE_NAME}" == "cuda" ]]; then
             docker exec -t "${container_name}" bash -c "
-              pip install torchao==0.16.0 fbgemm-gpu-genai==1.5.0
+              pip install torchao==0.17.0.dev20260305+cu130 fbgemm_gpu_genai==2026.3.4+cu130 --extra-index-url https://download.pytorch.org/whl/nightly
 
               # A quick mitigation for https://github.com/vllm-project/vllm/issues/32373
               rm /etc/ld.so.conf.d/cuda-compat.conf || true

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -295,6 +295,7 @@ jobs:
           SCCACHE_REGION: us-east-1
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HOME: /mnt/hf_cache
+          TRANSFORMERS_OFFLINE: 1
           DOCKER_IMAGE: ${{ env.DOCKER_IMAGE_PREFIX }}:${{ env.HEAD_SHA }}${{ env.DOCKER_IMAGE_SUFFIX }}
           # vLLM-related environment variables
           ENGINE_VERSION: v1
@@ -313,6 +314,9 @@ jobs:
             export HF_HOME="${RUNNER_TEMP}/hf_cache"
             mkdir -p "${HF_HOME}"
 
+            # When there is no cache directory, e.g. benchmark, the job has no
+            # way but to reach out to HF if needed
+            export TRANSFORMERS_OFFLINE=0
           fi
 
           container_name=$(docker run \
@@ -324,6 +328,7 @@ jobs:
             -e DEVICE_TYPE \
             -e HF_TOKEN \
             -e HF_HOME \
+            -e TRANSFORMERS_OFFLINE \
             -e ENGINE_VERSION \
             -e SAVE_TO_PYTORCH_BENCHMARK_FORMAT \
             -e ON_CPU="${ON_CPU}" \

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -347,7 +347,8 @@ jobs:
           )
           if [[ "${DEVICE_NAME}" == "cuda" ]]; then
             docker exec -t "${container_name}" bash -c "
-              pip install torchao==0.15.0 fbgemm-gpu-genai==1.5.0 --extra-index-url https://download.pytorch.org/whl/cu130
+              # Put fbgemm-gpu-genai back once it has a version working with 2.11
+              pip install torchao==0.15.0 --extra-index-url https://download.pytorch.org/whl/cu130
 
               # A quick mitigation for https://github.com/vllm-project/vllm/issues/32373
               rm /etc/ld.so.conf.d/cuda-compat.conf || true


### PR DESCRIPTION
Use torchao 0.15.0 because of https://github.com/pytorch/pytorch/issues/175435#issuecomment-4015058209

This is used to test PyTorch 2.11 RC from https://github.com/vllm-project/vllm/pull/34644

cc @atalman 