### PR TITLE
[tritonbench] Run only the specific triton channel and commit

### DIFF
--- a/.github/workflows/tritonbench.yml
+++ b/.github/workflows/tritonbench.yml
@@ -22,6 +22,16 @@ on:
         required: true
         type: string
         default: b200
+      triton_channel:
+        description: |
+          Triton channel to run: all (default, runs both triton-main and meta-triton), triton-main, or meta-triton
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - triton-main
+          - meta-triton
       benchmark_parameters:
         description: Extra parameters to pass to run-benchmark.sh (optional)
         required: false
@@ -52,13 +62,21 @@ jobs:
         env:
           BENCHMARKS: ${{ inputs.benchmarks || '' }}
           RUNNERS: ${{ inputs.runners || '' }}
+          TRITON_CHANNEL: ${{ inputs.triton_channel || 'all' }}
         run: |
           set -eux
+
+          if [ "${TRITON_CHANNEL}" == "all" ]; then
+            TRITON="triton-main,meta-triton"
+          else
+            TRITON="${TRITON_CHANNEL}"
+          fi
 
           # The generated matrix is grouped by benchmark and runner
           python .github/scripts/generate_tritonbench_matrix.py \
             --benchmarks "${BENCHMARKS}" \
-            --runners "${RUNNERS}"
+            --runners "${RUNNERS}" \
+            --triton "${TRITON}"
 
 
   benchmarks:

--- a/.github/workflows/tritonbench.yml
+++ b/.github/workflows/tritonbench.yml
@@ -32,6 +32,16 @@ on:
           - all
           - triton-main
           - meta-triton
+      triton_repo:
+        description: Triton repo to build from (optional)
+        required: false
+        type: string
+        default: ''
+      triton_commit:
+        description: Triton commit or ref to build from (optional)
+        required: false
+        type: string
+        default: ''
       benchmark_parameters:
         description: Extra parameters to pass to run-benchmark.sh (optional)
         required: false
@@ -169,16 +179,42 @@ jobs:
         working-directory: triton-benchmarks/tritonbench
         run: |
           set -eux
-          # Use MAX_JOBS=16 to avoid OOM compiling Triton
-          if [ "${CONDA_ENV}" == "triton-main" ]; then
-              CMD_SUFFIX="--triton-main"
+          bash ./.ci/tritonbench/setup-env.sh --cuda
+
+      - name: Compile Triton
+        working-directory: triton-benchmarks/tritonbench
+        env:
+          INPUT_TRITON_REPO: ${{ inputs.triton_repo || '' }}
+          INPUT_TRITON_COMMIT: ${{ inputs.triton_commit || '' }}
+        run: |
+          set -eux
+
+          if [ -n "${INPUT_TRITON_REPO}" ]; then
+              TRITON_REPO="${INPUT_TRITON_REPO}"
+          elif [ "${CONDA_ENV}" == "triton-main" ]; then
+              TRITON_REPO="triton-lang/triton"
           elif [ "${CONDA_ENV}" == "meta-triton" ]; then
-              CMD_SUFFIX="--meta-triton"
+              TRITON_REPO="facebookexperimental/triton"
           else
               echo "unknown conda env: ${CONDA_ENV}"
               exit 1
           fi
-          MAX_JOBS=16 bash ./.ci/tritonbench/setup-env.sh --cuda ${CMD_SUFFIX}
+
+          if [ -n "${INPUT_TRITON_COMMIT}" ]; then
+              TRITON_COMMIT="${INPUT_TRITON_COMMIT}"
+              NIGHTLY_FLAG=""
+          else
+              TRITON_COMMIT="main"
+              NIGHTLY_FLAG="--nightly"
+          fi
+
+          MAX_JOBS=16 bash ./.ci/triton/install.sh \
+              --conda-env "${CONDA_ENV}" \
+              --repo "${TRITON_REPO}" \
+              --commit "${TRITON_COMMIT}" \
+              --side single \
+              --install-dir "${WORKSPACE_DIR}/${CONDA_ENV}" \
+              ${NIGHTLY_FLAG}
 
       - name: Run TritonBench
         working-directory: triton-benchmarks/tritonbench


### PR DESCRIPTION
By default, we will run both triton-main and meta-triton channels. 

This PR gives flexibility to run only one triton channel and compile the requested Triton commit in the workflow-dispatch benchmark.

Test plan:

https://github.com/pytorch/pytorch-integration-testing/actions/runs/23819801683