### PR TITLE
[tritonbench] Use ci dependency group in TritonBench workflow

### DIFF
--- a/.github/workflows/tritonbench.yml
+++ b/.github/workflows/tritonbench.yml
@@ -173,7 +173,7 @@ jobs:
         working-directory: triton-benchmarks/tritonbench
         run: |
           set -eux
-          pip install -r .ci/upload/requirements.txt
+          pip install --group ci
 
       - name: Install TritonBench
         working-directory: triton-benchmarks/tritonbench


### PR DESCRIPTION
We removed `requirements.txt` and replaced it with `pip install --group ci` in the upstream


Test plan:

https://github.com/pytorch/pytorch-integration-testing/actions/runs/24253171674
