### PR TITLE
[torch-bisect] fix repro cmdline bug and enhance with more cases

### DIFF
--- a/.github/scripts/bisect/run.sh
+++ b/.github/scripts/bisect/run.sh
@@ -15,6 +15,7 @@ required_envs=(
   CUDA_HOME
   FUNCTIONAL
   REPRO_CMDLINE
+  USE_UV
 )
 
 for env_name in "${required_envs[@]}"; do
@@ -76,7 +77,7 @@ elif [ ${PREFLIGHT_RC} -ne 1 ] && [ ${FUNCTIONAL} -ne 1 ]; then
 fi
 
 # kick off the bisect!
-BASELINE_LOG="${BASELINE_LOG}" USE_UV=0 \
+BASELINE_LOG="${BASELINE_LOG}" USE_UV="${USE_UV}" \
 tritonparseoss bisect \
   --no-tui \
   --target torch \

--- a/.github/scripts/bisect/run.sh
+++ b/.github/scripts/bisect/run.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly DETECTOR="${WORKSPACE_DIR}/.ci/bisect/regression_detector.py"
+readonly DETECTOR="${WORKSPACE_DIR}/.github/scripts/bisect/regression_detector.py"
 
 required_envs=(
   WORKSPACE_DIR

--- a/.github/scripts/bisect/run.sh
+++ b/.github/scripts/bisect/run.sh
@@ -47,6 +47,7 @@ bash ${tritonparse_dir}/bisect/scripts/prepare_build_pytorch.sh
 BASELINE_LOG="${LOG_DIR}/baseline.log"
 checkout_pytorch_commit "${PYTORCH_SRC_DIR}" "${GOOD_COMMIT}"
 bash ${tritonparse_dir}/bisect/scripts/build_pytorch.sh
+cd ${PYTORCH_SRC_DIR}
 eval ${REPRO_CMDLINE} 2>&1 | tee "${BASELINE_LOG}"
 
 # step 3: build and run the bad commit

--- a/.github/scripts/bisect/run.sh
+++ b/.github/scripts/bisect/run.sh
@@ -24,7 +24,7 @@ for env_name in "${required_envs[@]}"; do
   fi
 done
 
-if [ ! -e ${DETECTOR} ]; do
+if [ ! -e ${DETECTOR} ]; then
     echo "Missing detector script: ${DETECTOR}."
     exit 1
 fi

--- a/.github/scripts/bisect/run.sh
+++ b/.github/scripts/bisect/run.sh
@@ -24,6 +24,11 @@ for env_name in "${required_envs[@]}"; do
   fi
 done
 
+if [ ! -e ${DETECTOR} ]; do
+    echo "Missing detector script: ${DETECTOR}."
+    exit 1
+fi
+
 checkout_pytorch_commit() {
   local repo_dir="$1"
   local commit="$2"
@@ -55,7 +60,7 @@ checkout_pytorch_commit "${PYTORCH_SRC_DIR}" "${BAD_COMMIT}"
 bash ${tritonparse_dir}/bisect/scripts/build_pytorch.sh
 # allow the regression detector to exit with error code
 set +e
-BASELINE_LOG="${BASELINE_LOG}" python ./.ci/bisect/regression_detector.py
+BASELINE_LOG="${BASELINE_LOG}" python "${DETECTOR}"
 PREFLIGHT_RC=$?
 set -e
 

--- a/.github/workflows/pytorch-bisect.yaml
+++ b/.github/workflows/pytorch-bisect.yaml
@@ -82,6 +82,13 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Checkout torchbench
+        uses: actions/checkout@v4
+        with:
+          repository: pytorch/benchmark
+          path: torch-benchmarks/benchmark
+          fetch-depth: 0
+
       - name: Checkout torchvision
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/pytorch-bisect.yaml
+++ b/.github/workflows/pytorch-bisect.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: pytorch-labs/tritonparse
           path: torch-benchmarks/tritonparse
-          ref: main
+          ref: xz9/fix-bisect
           fetch-depth: 0
 
       - name: Checkout PyTorch

--- a/.github/workflows/pytorch-bisect.yaml
+++ b/.github/workflows/pytorch-bisect.yaml
@@ -58,6 +58,7 @@ jobs:
       PYTORCH_REPO: pytorch/pytorch
       FUNCTIONAL: ${{ inputs.type == 'functional' && '1' || '0' }}
       CUDA_HOME: ${{ github.workspace }}/torch-benchmarks/cuda
+      CUDA_VERSION: "13.0"
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/pytorch-bisect.yaml
+++ b/.github/workflows/pytorch-bisect.yaml
@@ -49,6 +49,7 @@ jobs:
     name: Run PyTorch Bisect
     runs-on: ${{ inputs.runner }}
     env:
+      USE_UV: '1'
       WORKSPACE_DIR: ${{ github.workspace }}
       GOOD_COMMIT: ${{ inputs.good_commit }}
       BAD_COMMIT: ${{ inputs.bad_commit }}

--- a/.github/workflows/pytorch-bisect.yaml
+++ b/.github/workflows/pytorch-bisect.yaml
@@ -52,10 +52,10 @@ jobs:
       WORKSPACE_DIR: ${{ github.workspace }}
       GOOD_COMMIT: ${{ inputs.good_commit }}
       BAD_COMMIT: ${{ inputs.bad_commit }}
+      REPRO_CMDLINE: ${{ inputs.repro_cmdline }}
       REGRESSION_THRESHOLD: ${{ inputs.regression_threshold }}
       PYTORCH_REPO: pytorch/pytorch
       FUNCTIONAL: ${{ inputs.type == 'functional' && '1' || '0' }}
-      REPRO_CMDLINE: ${{ inputs.command_arguments }}
       CUDA_HOME: ${{ github.workspace }}/torch-benchmarks/cuda
     permissions:
       id-token: write
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: pytorch-labs/tritonparse
           path: torch-benchmarks/tritonparse
-          ref: xz9/add-torch-bisect
+          ref: main
           fetch-depth: 0
 
       - name: Checkout PyTorch


### PR DESCRIPTION
```
Last good commit: 9d49044
First bad commit: 34cdf49
Metric: geomean_speedup
Threshold: 0.95
Rel_tol: 0.001
Dtype: amp
Arch: b200
Device: cuda
Suite: timm_models
Compiler: cudagraphs
Mode: training
Branch: main
Repo: pytorch/pytorch
Model: inception_v3
Regression: 3.59x -> 3.33x (7.5%)
REPRO_CMD: python benchmarks/dynamo/timm_models.py --performance --amp --training --only inception_v3 --inductor
```

Test workflow:
https://github.com/pytorch/pytorch-integration-testing/actions/runs/24430996449

The workflow works, however, the regression could not be reproduced:

```
No regression detected: current value 3.881, 3.888 / 3.881 - 1 == 0.1803658850811677%, threshold 4.0%)
```


Regression report 2:

```
Between commits 7ba94e7f (Apr 12) and 437c81a2 (Apr 13), 20+ torchbench models dropped 13-22% speedup on H100 bfloat16 inference:
nanogpt: 8.67x to 6.72x (-22%)
phlippe_resnet: 5.63x to 4.51x (-20%)
squeezenet1_1: 4.20x to 3.39x (-19%)
mobilenet_v3_large: 5.80x to 4.78x (-18%)
```

Command:

```
python benchmarks/dynamo/torchbench.py --performance --bfloat16 --inference --only mobilenet_v3_large --inductor
```

```
python benchmarks/dynamo/torchbench.py --performance --bfloat16 --inference --only nanogpt --inductor
```

Test workflow:

(h100, mobilenet_v3_large)
https://github.com/pytorch/pytorch-integration-testing/actions/runs/24477745032

(h100, nanogpt)
https://github.com/pytorch/pytorch-integration-testing/actions/runs/24481090032