### PR TITLE
ci: declare contents:read on Flash Attention Benchmark workflow

### DIFF
--- a/.github/workflows/flash_attention.yml
+++ b/.github/workflows/flash_attention.yml
@@ -17,6 +17,8 @@ jobs:
   benchmark-flash-attn:
     name: Flash Attention CuTe DSL Benchmark
     runs-on: linux.dgx.b200.8
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The `Flash Attention Benchmark` workflow runs nightly on `linux.dgx.b200.8`, checks out this repo + `Dao-AILab/flash-attention`, and runs the benchmark scripts. There's no GitHub API write beyond `actions/checkout`.

This patch pins the job to `permissions: contents: read`, matching the per-job permission blocks already declared by `tritonbench.yml`, `tritonbench-bisect.yml`, `vllm-benchmark.yml`, `vllm-ci-test.yml`, `vllm-profiling.yml`, `sglang-benchmark.yml`, and `pytorch-bisect.yaml`.

With explicit scope:

- the workflow token can't be widened by a future change to the repo default
- the SLSA / OpenSSF Scorecard `Token-Permissions` check passes for this file
- a hypothetical compromise of `actions/checkout` (cf. tj-actions/changed-files CVE-2025-30066) stays boxed in read-only

`inductor.yml` is the other workflow without an explicit `permissions:` block, but it calls the reusable `pytorch/test-infra/.github/workflows/linux_job.yml@main` workflow. Declaring permissions on the caller would intersect with the callee's grant, so I've left it out of this PR.

No behavioural change.