### PR TITLE
[tritonbench] use the new setup-env.sh

### DIFF
--- a/.github/workflows/tritonbench.yml
+++ b/.github/workflows/tritonbench.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Checkout Triton
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.triton_repo || 'triton-lang/triton' }}
+          repository: ${{ inputs.triton_repo || (matrix.triton_channel == 'meta-triton' && 'facebookexperimental/triton' || 'triton-lang/triton') }}
           path: triton-benchmarks/triton
           ref: ${{ inputs.triton_commit || 'main' }}
           submodules: recursive

--- a/.github/workflows/tritonbench.yml
+++ b/.github/workflows/tritonbench.yml
@@ -103,7 +103,7 @@ jobs:
       UV_VENV_DIR: "/workspace/uv_venvs"
       CONDA_ENV: ${{ matrix.triton_channel }}
       TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-      JOB_NAME: tritonbench-${{ matrix.runner }}-benchmark-${{ matrix.triton_channel }}--periodic-${{ matrix.benchmarks }}
+      JOB_NAME: tritonbench-${{ matrix.runner }}-benchmark-${{ matrix.triton_channel }}-periodic-${{ matrix.benchmarks }}
       RUNNER_TYPE: ${{ matrix.runner }}
     environment: pytorch-x-vllm
     permissions:
@@ -193,9 +193,13 @@ jobs:
 
           # If running in nightly environment
           # Check out the "nightly" commit
-          bash ./.ci/triton/install.sh \
-          --install-dir ${GITHUB_WORKSPACE}/triton-benchmarks/triton \
-          --checkout nightly
+          if [ -z ${{ inputs.triton_repo }} ] && \
+             [ -z ${{ inputs.triton_commit }} ]; then
+              . ./.ci/triton/triton_install_utils.sh
+              checkout_triton main \
+                  "${GITHUB_WORKSPACE}/triton-benchmarks/triton" \
+                  "1"
+          fi
 
           bash ./.ci/tritonbench/setup-env.sh --cuda \
               --custom-triton ${GITHUB_WORKSPACE}/triton-benchmarks/triton

--- a/.github/workflows/tritonbench.yml
+++ b/.github/workflows/tritonbench.yml
@@ -135,7 +135,7 @@ jobs:
           path: triton-benchmarks/triton
           ref: ${{ inputs.triton_commit || 'main' }}
           submodules: recursive
-          fetch-depth: 0
+          fetch-depth: 100
 
       - uses: actions/setup-python@v5
         # Amazon Linux fails on this step

--- a/.github/workflows/tritonbench.yml
+++ b/.github/workflows/tritonbench.yml
@@ -128,6 +128,15 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Checkout Triton
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.triton_repo || 'triton-lang/triton' }}
+          path: triton-benchmarks/triton
+          ref: ${{ inputs.triton_commit || 'main' }}
+          submodules: recursive
+          fetch-depth: 0
+
       - uses: actions/setup-python@v5
         # Amazon Linux fails on this step
         continue-on-error: true
@@ -175,46 +184,21 @@ jobs:
           set -eux
           pip install --group ci
 
-      - name: Install TritonBench
-        working-directory: triton-benchmarks/tritonbench
-        run: |
-          set -eux
-          bash ./.ci/tritonbench/setup-env.sh --cuda
-
-      - name: Compile Triton
+      - name: Install TritonBench and Build Triton
         working-directory: triton-benchmarks/tritonbench
         env:
-          INPUT_TRITON_REPO: ${{ inputs.triton_repo || '' }}
-          INPUT_TRITON_COMMIT: ${{ inputs.triton_commit || '' }}
+          MAX_JOBS: 16
         run: |
           set -eux
 
-          if [ -n "${INPUT_TRITON_REPO}" ]; then
-              TRITON_REPO="${INPUT_TRITON_REPO}"
-          elif [ "${CONDA_ENV}" == "triton-main" ]; then
-              TRITON_REPO="triton-lang/triton"
-          elif [ "${CONDA_ENV}" == "meta-triton" ]; then
-              TRITON_REPO="facebookexperimental/triton"
-          else
-              echo "unknown conda env: ${CONDA_ENV}"
-              exit 1
-          fi
+          # If running in nightly environment
+          # Check out the "nightly" commit
+          bash ./.ci/triton/install.sh \
+          --install-dir ${GITHUB_WORKSPACE}/triton-benchmarks/triton \
+          --checkout nightly
 
-          if [ -n "${INPUT_TRITON_COMMIT}" ]; then
-              TRITON_COMMIT="${INPUT_TRITON_COMMIT}"
-              NIGHTLY_FLAG=""
-          else
-              TRITON_COMMIT="main"
-              NIGHTLY_FLAG="--nightly"
-          fi
-
-          MAX_JOBS=16 bash ./.ci/triton/install.sh \
-              --conda-env "${CONDA_ENV}" \
-              --repo "${TRITON_REPO}" \
-              --commit "${TRITON_COMMIT}" \
-              --side single \
-              --install-dir "${WORKSPACE_DIR}/${CONDA_ENV}" \
-              ${NIGHTLY_FLAG}
+          bash ./.ci/tritonbench/setup-env.sh --cuda \
+              --custom-triton ${GITHUB_WORKSPACE}/triton-benchmarks/triton
 
       - name: Run TritonBench
         working-directory: triton-benchmarks/tritonbench

--- a/.github/workflows/tritonbench.yml
+++ b/.github/workflows/tritonbench.yml
@@ -135,7 +135,6 @@ jobs:
           path: triton-benchmarks/triton
           ref: ${{ inputs.triton_commit || 'main' }}
           submodules: recursive
-          fetch-depth: 100
 
       - uses: actions/setup-python@v5
         # Amazon Linux fails on this step

--- a/.github/workflows/tritonbench.yml
+++ b/.github/workflows/tritonbench.yml
@@ -200,19 +200,8 @@ jobs:
                   "1"
           fi
 
-          CMD_SUFFIX=""
-          if [ "${CONDA_ENV}" == "triton-main" ]; then
-              CMD_SUFFIX="--triton-main"
-          elif [ "${CONDA_ENV}" == "meta-triton" ]; then
-              CMD_SUFFIX="--meta-triton"
-          else
-              echo "unknown conda env: ${CONDA_ENV}"
-              exit 1
-          fi
-
           bash ./.ci/tritonbench/setup-env.sh --cuda \
-              --custom-triton ${GITHUB_WORKSPACE}/triton-benchmarks/triton \
-              ${CMD_SUFFIX}
+              --custom-triton ${GITHUB_WORKSPACE}/triton-benchmarks/triton
 
       - name: Run TritonBench
         working-directory: triton-benchmarks/tritonbench

--- a/.github/workflows/tritonbench.yml
+++ b/.github/workflows/tritonbench.yml
@@ -201,8 +201,19 @@ jobs:
                   "1"
           fi
 
+          CMD_SUFFIX=""
+          if [ "${CONDA_ENV}" == "triton-main" ]; then
+              CMD_SUFFIX="--triton-main"
+          elif [ "${CONDA_ENV}" == "meta-triton" ]; then
+              CMD_SUFFIX="--meta-triton"
+          else
+              echo "unknown conda env: ${CONDA_ENV}"
+              exit 1
+          fi
+
           bash ./.ci/tritonbench/setup-env.sh --cuda \
-              --custom-triton ${GITHUB_WORKSPACE}/triton-benchmarks/triton
+              --custom-triton ${GITHUB_WORKSPACE}/triton-benchmarks/triton \
+              ${CMD_SUFFIX}
 
       - name: Run TritonBench
         working-directory: triton-benchmarks/tritonbench


### PR DESCRIPTION
Tritonbench has refactored `setup-env.sh` to decouple Triton code checkout and build.
Adapt to the new interface.

Test workflow:

https://github.com/pytorch/pytorch-integration-testing/actions/runs/26345853333

Test workflow 2:

https://github.com/pytorch/pytorch-integration-testing/actions/runs/26346811909