### PR TITLE
[tritonbench] use uv pip to install ci deps

### DIFF
--- a/.github/workflows/tritonbench.yml
+++ b/.github/workflows/tritonbench.yml
@@ -196,8 +196,9 @@ jobs:
           bash ./.ci/tritonbench/setup-env.sh --cuda \
               --custom-triton ${GITHUB_WORKSPACE}/triton-benchmarks/triton
 
+          deactivate
           . "${SETUP_SCRIPT}"
-          pip install --group ci
+          $HOME/.local/bin/uv pip install --group ci
 
       - name: Run TritonBench
         working-directory: triton-benchmarks/tritonbench

--- a/.github/workflows/tritonbench.yml
+++ b/.github/workflows/tritonbench.yml
@@ -176,13 +176,6 @@ jobs:
           fi
           echo "DEVICE_TYPE=$DEVICE_TYPE" >> $GITHUB_ENV
 
-      - name: Install dependencies
-        shell: bash
-        working-directory: triton-benchmarks/tritonbench
-        run: |
-          set -eux
-          pip install --group ci
-
       - name: Install TritonBench and Build Triton
         working-directory: triton-benchmarks/tritonbench
         env:
@@ -202,6 +195,9 @@ jobs:
 
           bash ./.ci/tritonbench/setup-env.sh --cuda \
               --custom-triton ${GITHUB_WORKSPACE}/triton-benchmarks/triton
+
+          . "${SETUP_SCRIPT}"
+          uv pip install --group ci
 
       - name: Run TritonBench
         working-directory: triton-benchmarks/tritonbench

--- a/.github/workflows/tritonbench.yml
+++ b/.github/workflows/tritonbench.yml
@@ -197,7 +197,7 @@ jobs:
               --custom-triton ${GITHUB_WORKSPACE}/triton-benchmarks/triton
 
           . "${SETUP_SCRIPT}"
-          uv pip install --group ci
+          pip install --group ci
 
       - name: Run TritonBench
         working-directory: triton-benchmarks/tritonbench

--- a/.github/workflows/tritonbench.yml
+++ b/.github/workflows/tritonbench.yml
@@ -196,8 +196,8 @@ jobs:
           bash ./.ci/tritonbench/setup-env.sh --cuda \
               --custom-triton ${GITHUB_WORKSPACE}/triton-benchmarks/triton
 
-          deactivate
           . "${SETUP_SCRIPT}"
+          . "${UV_VENV_DIR}/${CONDA_ENV}/bin/activate"
           $HOME/.local/bin/uv pip install --group ci
 
       - name: Run TritonBench


### PR DESCRIPTION
The default `pip` in CI environment doesn't support `install --group`: https://github.com/pytorch/pytorch-integration-testing/actions/runs/26576260449

Force it to use `uv pip install --group`.

https://github.com/pytorch/pytorch-integration-testing/actions/runs/26588381937